### PR TITLE
Enable local docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM openjdk:8u121-jre
-MAINTAINER Kieran Wardle <kieran.wardle@ons.gov.uk>
-ARG jar
+FROM openjdk:8-jre
+
 VOLUME /tmp
-COPY $jar samplesvc.jar
-ENV JAVA_OPTS=""
-ENTRYPOINT [ "sh", "-c", "java -jar /samplesvc.jar" ]
+COPY target/samplesvc*.jar /opt/samplesvc.jar
+
+ENTRYPOINT [ "java", "-jar", "/opt/samplesvc.jar" ]

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>1.3.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <repository>sdcplatform/${project.artifactId}</repository>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <resources>


### PR DESCRIPTION
The Dockerfile expected the jar location to be passed in as an extra
parameter making the builds not work as easily out of the box. Maven
will always build jars to the same locations so we can expect the jar to
be there.

Adding spotify docker plugin will allow us to hook into the maven build
to produce a docker image when running mvn install. The overhead of
creating the docker image when running the build is around 14s.

Implemented following the spring boot guide:
https://spring.io/guides/gs/spring-boot-docker/