### PR TITLE
Added servlet exclusion for cobertura dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>
       <artifactId>cobertura</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api-2.5</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Prevents NoSuchMethodErrors when running the application