### PR TITLE
Integration test for bres upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ jdk: openjdk8
 
 before_install: cp .travis.settings.xml $HOME/.m2/settings.xml
 
+script: mvn clean verify
+
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2'
+services:
+ postgres:
+  container_name: postgres
+  image: sdcplatform/postgres
+  ports:
+   - "6432:5432"
+ redis:
+  container_name: redis
+  image: redis:3.2.9
+  ports:
+   - "7379:6379"
+ rabbitmq:
+  container_name: rabbitmq
+  image: rabbitmq:3.6.10-management
+  ports:
+    - "5369:4369"
+    - "45672:25672"
+    - "6671:5671"
+    - "6672:5672"
+    - "16671:15671"
+    - "16672:15672"
+ sftp:
+    container_name: sftp
+    image: atmoz/sftp
+    volumes:
+        - ~/Documents/sftp:/home/centos/Documents/sftp
+    ports:
+        - "122:22"
+    command: centos:JLibV2&XD,:1001
+ party-service:
+  container_name: party-service
+  image: sdcplatform/ras-party
+  links:
+        - "postgres:postgres"
+  ports:
+    - "5062:5062"
+  environment:
+    - ras-party-db.uri=postgresql://postgres:postgres@postgres:5432/postgres
+    - SECURITY_USER_NAME=admin
+    - SECURITY_USER_PASSWORD=secret

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-solr</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.mashape.unirest</groupId>
+      <artifactId>unirest-java</artifactId>
+      <version>1.4.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -200,6 +206,29 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>*/**IT.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.18.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <!-- rerun tests because schema isn't create successfully first time -->
+              <rerunFailingTestsCount>2</rerunFailingTestsCount>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -240,6 +269,64 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.23.0</version>
+        <executions>
+          <execution>
+            <id>pre-stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <showLogs>false</showLogs>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
     <resources>

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -1,0 +1,50 @@
+package uk.gov.ons.ctp.response.sample.endpoint;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.http.entity.ContentType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
+import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SampleEndpointIT {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    public void shouldUploadSampleFile() throws UnirestException, IOException {
+        // Given
+        final String sampleFile = "/csv/business-survey-sample.csv";
+
+        // When
+        HttpResponse<String> sampleSummaryResponse = Unirest.post("http://localhost:" + port + "/samples/bres/fileupload")
+                .basicAuth("admin", "secret")
+                .field("file", getClass().getResourceAsStream(sampleFile), ContentType.MULTIPART_FORM_DATA, "file")
+                .asString();
+
+        // Then
+        assertThat(sampleSummaryResponse.getStatus()).isEqualTo(201);
+        SampleSummary sampleSummary = mapper.readValue(sampleSummaryResponse.getBody(), new TypeReference<SampleSummary>() {});
+        assertThat(sampleSummary.getState()).isEqualTo(SampleSummaryDTO.SampleState.INIT);
+    }
+}


### PR DESCRIPTION
An example of how we could localise our integration testing to:
* Increase code change feedback
* Speed up end to end/acceptance test builds
* Self document how services behave


Create integration tests to test an upload of a bres sample file is
successful. The integration test requires the following services to be
running:
* postgres
* redis
* rabbitmq
* sftp
* ras-party

The tests could be extended to ensure messages are put on rabbitmq or
data has been inserted into the database. Ideally you would test these
via an API even if that means introducing them to make testing easier.