### PR TITLE
Change docker-info final name to avoid clashes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
             </goals>
             <phase>package</phase>
             <configuration>
+              <finalName>docker-info-${project.artifactId}</finalName>
               <repository>sdcplatform/${project.artifactId}</repository>
             </configuration>
           </execution>


### PR DESCRIPTION
The docker-info file causes issues where we assume only one
${project.artifactId}*.jar file is output. This change means those types
of wildcards will still work.

This will also allow repeated builds without `mvn clean`