### PR TITLE
Remove IT excludes in surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,11 +206,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>*/**IT.java</exclude>
-          </excludes>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Surefire only runs test with the formats: "**/Test*.java",
"**/*Test.java", "**/*Tests.java", "**/*TestCase.java" so it isn't
necessary to exclude the IT. It was causing some issue with
maven-checkstyle-plugin. We were getting the error
```
[ERROR] Failed to
execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check
(test) on project samplesvc: Unable to parse configuration of mojo
org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check: Basic
element 'excludes' must not contain child elements```