### PR TITLE
14 create release artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+ARG JAR_FILE=samplesvc*.jar
 FROM openjdk:8-jre
 
 VOLUME /tmp
-COPY target/samplesvc*.jar /opt/samplesvc.jar
+ARG JAR_FILE
+COPY target/$JAR_FILE /opt/samplesvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/samplesvc.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-ARG JAR_FILE=samplesvc*.jar
 FROM openjdk:8-jre
 
 VOLUME /tmp
-ARG JAR_FILE
+ARG JAR_FILE=samplesvc*.jar
 COPY target/$JAR_FILE /opt/samplesvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/samplesvc.jar" ]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>samplesvc</artifactId>
-  <version>10.49.2-SNAPSHOT</version>
+  <version>10.49.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : SampleService</name>
@@ -14,7 +14,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.6-SNAPSHOT</version>
+    <version>10.49.8</version>
   </parent>
 
   <scm>
@@ -32,19 +32,19 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.1-SNAPSHOT</version>
+      <version>10.50.2</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.3-SNAPSHOT</version>
+      <version>10.49.3</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>reportmodule</artifactId>
-      <version>10.49.1-SNAPSHOT</version>
+      <version>10.49.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.product</groupId>
@@ -259,8 +258,10 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <finalName>docker-info-${project.artifactId}</finalName>
               <repository>sdcplatform/${project.artifactId}</repository>
+              <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              </buildArgs>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>samplesvc</artifactId>
   <version>10.49.4-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -9,7 +8,6 @@
   <name>CTP : SampleService</name>
   <description>CTP : SampleService</description>
 
-  <!-- Inherit parent BOM to control versions of dependencies and plugin version & config -->
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
@@ -17,9 +15,9 @@
   </parent>
 
   <scm>
-    <connection>scm:git:git@github.com:ONSdigital/rm-sample-service.git</connection>
-    <developerConnection>scm:git:git@github.com:ONSdigital/rm-sample-service.git</developerConnection>
-    <url>git@github.com:ONSdigital/rm-sample-service.git</url>
+    <connection>scm:git:https://github.com/ONSdigital/rm-sample-service</connection>
+    <developerConnection>scm:git:https://github.com/ONSdigital/rm-sample-service</developerConnection>
+    <url>https://github.com/ONSdigital/rm-sample-service</url>
   </scm>
 
   <properties>


### PR DESCRIPTION
## What is it
These changes are driven to allow us to release artifacts in a much simpler way. Currently we have a bunch of shell scripts that we maintain to do releases when this is a core part of maven to be able to bump version, create tags and deploy artifacts.

* Bump versions and remove snapshot 
Release 13 was done on a branch where the version was incremented. The version change hasn't made it's way back into master yet so this change skips that version. We are also removing the snapshot versions.

* Using optional dockerfile buildArgs
We have been fighting with the `COPY target/samplesvc*.jar` syntax when
there is  more that one samplesvc*.jar file that  exists in the target
directory. Thought it was fixed by the docker info change but the same
issue occurs when doing a release because it builds the samplesvc-sources.jar.
This change makes the dockerfile JAR_FILE arg optional to allow the maven
build to provide the full name including version.

The output of the artifacts/tags are:
* A tag called `${project.artifactId}-${project.version} e.g. samplesvc-0.49.5
* 3 artifacts called `${project.artifactId}-${project.version}-${classifier} e.g. samplesvc-0.49.5.jar, samplesvc-0.49.5-sources.jar
* A version of the pom.xml in artifactory in the format samplesvc-0.49.5.pom
## Testing
1. Checkout branch
2.  `export ARTIFACTORY_PASSWORD=$REAL_PASSWORD`
3. `mvn -B release:prepare release:perform -Darguments="-Dmaven.javadoc.skip=true"`