### PR TITLE
Defect-R17_2-Receive and pass on collectionExerciseId to party

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.2</version>
+      <version>10.50.5-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.7-SNAPSHOT</version>
+      <version>10.49.6</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.6</version>
+      <version>10.49.7-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -98,15 +98,18 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   }
 
   @RequestMapping(value = "/{type}/fileupload", method = RequestMethod.POST, consumes = "multipart/form-data")
-  public final @ResponseBody ResponseEntity<SampleSummary> uploadSampleFile(@PathVariable("type") final String type, @RequestParam("file") MultipartFile file) throws CTPException {
-    log.debug("Entering Sample file upload for Type {}", type);
-    if (!Arrays.asList("B", "CENSUS", "SOCIAL").contains(type.toUpperCase())) {
-      return ResponseEntity.badRequest().build();
+  public final @ResponseBody ResponseEntity<SampleSummary> uploadSampleFile(@PathVariable("type") final String type,
+                                                                            @RequestParam("file") MultipartFile file,
+                                                                            @RequestParam("collectionExerciseId") String collectionExerciseId)
+          throws CTPException {
+      log.debug("Entering Sample file upload for Type {}", type);
+      if (!Arrays.asList("B", "CENSUS", "SOCIAL").contains(type.toUpperCase())) {
+        return ResponseEntity.badRequest().build();
     }
 
     SampleSummary sampleSummary;
     try {
-      sampleSummary = sampleService.ingest(file, type);
+      sampleSummary = sampleService.ingest(file, type, collectionExerciseId);
     } catch (Exception e) {
       throw new CTPException(CTPException.Fault.VALIDATION_FAILED, e, "Error ingesting file %s", file.getOriginalFilename());
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -85,7 +85,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
     columnPositionMappingStrategy.setColumnMapping(COLUMNS);
   }
 
-  public SampleSummary ingest(MultipartFile file)
+  public SampleSummary ingest(MultipartFile file, String collectionExerciseId)
       throws Exception {
 
     CSVReader csvReader = new CSVReader(new InputStreamReader(file.getInputStream()), ':');
@@ -114,7 +114,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
 
       businessSurveySample.setSampleUnits(samplingUnitList);
 
-      sampleSummary = sampleService.processSampleSummary(businessSurveySample, samplingUnitList, expectedCI);
+      sampleSummary = sampleService.processSampleSummary(businessSurveySample, samplingUnitList, expectedCI, collectionExerciseId);
 
     return sampleSummary;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -83,7 +83,7 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
     columnPositionMappingStrategy.setColumnMapping(COLUMNS);
   }
 
-  public SampleSummary ingest(MultipartFile file)
+  public SampleSummary ingest(MultipartFile file, String collectionExerciseId)
       throws Exception {
 
     CSVReader csvReader = new CSVReader(new InputStreamReader(file.getInputStream()), ':');
@@ -112,7 +112,7 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
 
       censusSurveySample.setSampleUnits(samplingUnitList);
 
-      sampleSummary = sampleService.processSampleSummary(censusSurveySample, samplingUnitList, expectedCI);
+      sampleSummary = sampleService.processSampleSummary(censusSurveySample, samplingUnitList, expectedCI, collectionExerciseId);
 
     return sampleSummary;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -57,7 +57,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
     columnPositionMappingStrategy.setColumnMapping(COLUMNS);
   }
 
-  public SampleSummary ingest(MultipartFile file)
+  public SampleSummary ingest(MultipartFile file, String collectionExerciseId)
       throws Exception {
 
     CSVReader csvReader = new CSVReader(new InputStreamReader(file.getInputStream()), ':');
@@ -84,7 +84,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
 
       businessSurveySample.setSampleUnits(samplingUnitList);
 
-      sampleSummary = sampleService.processSampleSummary(businessSurveySample, samplingUnitList, expectedCI);
+      sampleSummary = sampleService.processSampleSummary(businessSurveySample, samplingUnitList, expectedCI, collectionExerciseId);
 
     return sampleSummary;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -51,7 +51,6 @@ public class PartyUtil {
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
       businessSampleUnit.setCellNo(Integer.valueOf(bsu.getCell_no()));
-      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
       businessSampleUnit.setFormtype(bsu.getFormType());
       businessSampleUnit.setCurrency(bsu.getCurrency());
       party.setAttributes(businessSampleUnit);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -50,7 +50,8 @@ public class PartyUtil {
       businessSampleUnit.setTradstyle3(bsu.getTradstyle3());
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
-      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getCell_no()));
+      businessSampleUnit.setCellNo(Integer.valueOf(bsu.getCell_no()));
+      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
       businessSampleUnit.setFormtype(bsu.getFormType());
       businessSampleUnit.setCurrency(bsu.getCurrency());
       party.setAttributes(businessSampleUnit);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -32,12 +32,8 @@ public class PartyUtil {
       businessSampleUnit.setRusic92(bsu.getRusic92());
       businessSampleUnit.setFrosic2007(bsu.getFrosic2007());
       businessSampleUnit.setRusic2007(bsu.getRusic2007());
-      if (!bsu.getFroempment().equals("")) {
-        businessSampleUnit.setFroempment(Integer.valueOf(bsu.getFroempment()));
-      }
-      if (!bsu.getFrotover().equals("")) {
-        businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
-      }
+      businessSampleUnit.setFroempment(Integer.valueOf(bsu.getFroempment()));
+      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
       businessSampleUnit.setEntref(bsu.getEntref());
       businessSampleUnit.setLegalstatus(bsu.getLegalstatus());
       businessSampleUnit.setEntrepmkr(bsu.getEntrepmkr());
@@ -54,9 +50,7 @@ public class PartyUtil {
       businessSampleUnit.setTradstyle3(bsu.getTradstyle3());
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
-      if (!bsu.getCell_no().equals("")) {
-        businessSampleUnit.setFrotover(Integer.valueOf(bsu.getCell_no()));
-      }
+      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getCell_no()));
       businessSampleUnit.setFormtype(bsu.getFormType());
       businessSampleUnit.setCurrency(bsu.getCurrency());
       party.setAttributes(businessSampleUnit);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -59,7 +59,7 @@ public class PartyUtil {
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
       try {
-        businessSampleUnit.setCellNo(Integer.valueOf(bsu.getFrotover()));
+        businessSampleUnit.setCellNo(Integer.valueOf(bsu.getCell_no()));
       } catch (NumberFormatException nfe) {
         businessSampleUnit.setCellNo(0);
       }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -32,15 +32,11 @@ public class PartyUtil {
       businessSampleUnit.setRusic92(bsu.getRusic92());
       businessSampleUnit.setFrosic2007(bsu.getFrosic2007());
       businessSampleUnit.setRusic2007(bsu.getRusic2007());
-      try {
+      if (!bsu.getFroempment().equals("")) {
         businessSampleUnit.setFroempment(Integer.valueOf(bsu.getFroempment()));
-      } catch (NumberFormatException nfe) {
-        businessSampleUnit.setFroempment(0);
       }
-      try {
+      if (!bsu.getFrotover().equals("")) {
         businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
-      } catch (NumberFormatException nfe) {
-        businessSampleUnit.setFrotover(0);
       }
       businessSampleUnit.setEntref(bsu.getEntref());
       businessSampleUnit.setLegalstatus(bsu.getLegalstatus());
@@ -58,10 +54,8 @@ public class PartyUtil {
       businessSampleUnit.setTradstyle3(bsu.getTradstyle3());
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
-      try {
-        businessSampleUnit.setCellNo(Integer.valueOf(bsu.getCell_no()));
-      } catch (NumberFormatException nfe) {
-        businessSampleUnit.setCellNo(0);
+      if (!bsu.getCell_no().equals("")) {
+        businessSampleUnit.setFrotover(Integer.valueOf(bsu.getCell_no()));
       }
       businessSampleUnit.setFormtype(bsu.getFormType());
       businessSampleUnit.setCurrency(bsu.getCurrency());

--- a/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/party/PartyUtil.java
@@ -32,8 +32,16 @@ public class PartyUtil {
       businessSampleUnit.setRusic92(bsu.getRusic92());
       businessSampleUnit.setFrosic2007(bsu.getFrosic2007());
       businessSampleUnit.setRusic2007(bsu.getRusic2007());
-      businessSampleUnit.setFroempment(Integer.valueOf(bsu.getFroempment()));
-      businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
+      try {
+        businessSampleUnit.setFroempment(Integer.valueOf(bsu.getFroempment()));
+      } catch (NumberFormatException nfe) {
+        businessSampleUnit.setFroempment(0);
+      }
+      try {
+        businessSampleUnit.setFrotover(Integer.valueOf(bsu.getFrotover()));
+      } catch (NumberFormatException nfe) {
+        businessSampleUnit.setFrotover(0);
+      }
       businessSampleUnit.setEntref(bsu.getEntref());
       businessSampleUnit.setLegalstatus(bsu.getLegalstatus());
       businessSampleUnit.setEntrepmkr(bsu.getEntrepmkr());
@@ -50,7 +58,11 @@ public class PartyUtil {
       businessSampleUnit.setTradstyle3(bsu.getTradstyle3());
       businessSampleUnit.setSeltype(bsu.getSeltype());
       businessSampleUnit.setInclexcl(bsu.getInclexcl());
-      businessSampleUnit.setCellNo(Integer.valueOf(bsu.getCell_no()));
+      try {
+        businessSampleUnit.setCellNo(Integer.valueOf(bsu.getFrotover()));
+      } catch (NumberFormatException nfe) {
+        businessSampleUnit.setCellNo(0);
+      }
       businessSampleUnit.setFormtype(bsu.getFormType());
       businessSampleUnit.setCurrency(bsu.getCurrency());
       party.setAttributes(businessSampleUnit);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -39,8 +39,10 @@ public interface SampleService {
    * @param surveySampleObject SurveySample to be used
    * @throws Exception exception thrown
    */
-  SampleSummary processSampleSummary(SurveyBase surveySampleObject, List<? extends SampleUnitBase> samplingUnitList, Integer expectedCollectionInstruments)
-          throws Exception;
+  SampleSummary processSampleSummary(SurveyBase surveySampleObject,
+                                     List<? extends SampleUnitBase> samplingUnitList,
+                                     Integer expectedCollectionInstruments,
+                                     String collectionExerciseId) throws Exception;
 
   /**
    * Update the SampleSummary state
@@ -80,7 +82,7 @@ public interface SampleService {
    * @param type Type of Survey to be used
    * @throws Exception exception thrown
    */
-  SampleSummary ingest(MultipartFile file, String type) throws Exception;
+  SampleSummary ingest(MultipartFile file, String type, String collectionExerciseId) throws Exception;
 
   /**
    * find sampleUnit

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java
@@ -240,9 +240,9 @@ public class SampleServiceImpl implements SampleService {
       case "B":
         return csvIngesterBusiness.ingest(file, collectionExerciseId);
       case "CENSUS":
-        return csvIngesterCensus.ingest(file);
+        return csvIngesterCensus.ingest(file, collectionExerciseId);
       case "SOCIAL":
-        return csvIngesterSocial.ingest(file);
+        return csvIngesterSocial.ingest(file, collectionExerciseId);
       default:
         throw new UnsupportedOperationException(String.format("Type %s not implemented", type));
     }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -101,30 +101,30 @@ public class CsvIngesterBusinessTest {
 
   @Test
   public void testBlueSky() throws Exception {
-    csvIngester.ingest(getTestFile("business-survey-sample.csv"));
+    csvIngester.ingest(getTestFile("business-survey-sample.csv"), "test");
     verify(sampleService, times(1)).processSampleSummary(any(BusinessSurveySample.class),
-        anyListOf(BusinessSampleUnit.class), eq(1));
+        anyListOf(BusinessSampleUnit.class), eq(1), any(String.class));
   }
 
   @Test
   public void testMultipleLines() throws Exception {
-    csvIngester.ingest(getTestFile("business-survey-sample-multiple.csv"));
+    csvIngester.ingest(getTestFile("business-survey-sample-multiple.csv"), "test");
     verify(sampleService, times(1)).processSampleSummary(any(BusinessSurveySample.class),
-            anyListOf(BusinessSampleUnit.class), eq(3));
+            anyListOf(BusinessSampleUnit.class), eq(3), any(String.class));
   }
 
   @Test(expected = CTPException.class)
   public void testDate() throws Exception {
-    csvIngester.ingest(getTestFile("business-survey-sample-date.csv"));
+    csvIngester.ingest(getTestFile("business-survey-sample-date.csv"), "test");
     verify(sampleService, times(0)).processSampleSummary(any(BusinessSurveySample.class),
-        anyListOf(BusinessSampleUnit.class), eq(1));
+        anyListOf(BusinessSampleUnit.class), eq(1), "test");
   }
 
   @Test(expected = CTPException.class)
   public void missingColumns() throws Exception {
-    csvIngester.ingest(getTestFile("business-survey-sample-missing-columns.csv"));
+    csvIngester.ingest(getTestFile("business-survey-sample-missing-columns.csv"), "test");
     verify(sampleService, times(0)).processSampleSummary(any(BusinessSurveySample.class),
-        anyListOf(BusinessSampleUnit.class), eq(1));
+        anyListOf(BusinessSampleUnit.class), eq(1), "test");
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
@@ -71,24 +71,24 @@ public class CsvIngesterCensusTest {
 
   @Test
   public void testBlueSky() throws Exception {
-    csvIngester.ingest(getTestFile("census-survey-sample.csv"));
+    csvIngester.ingest(getTestFile("census-survey-sample.csv"), "test");
     verify(sampleService, times(1)).processSampleSummary(any(CensusSurveySample.class),
-            anyListOf(CensusSampleUnit.class), eq(1));
+            anyListOf(CensusSampleUnit.class), eq(1), any(String.class));
   }
 
   @Test(expected = Exception.class)
   public void missingColumns() throws Exception {
-    csvIngester.ingest(getTestFile("census-survey-sample-missing-columns.csv"));
+    csvIngester.ingest(getTestFile("census-survey-sample-missing-columns.csv"), "test");
     verify(sampleService, times(0)).processSampleSummary(any(CensusSurveySample.class),
-        anyListOf(CensusSampleUnit.class), eq(1));
+        anyListOf(CensusSampleUnit.class), eq(1), "test");
     thrown.expect(CTPException.class);
   }
 
   @Test(expected = Exception.class)
   public void incorrectData() throws Exception {
-    csvIngester.ingest(getTestFile("census-survey-sample-incorrect-data.csv"));
+    csvIngester.ingest(getTestFile("census-survey-sample-incorrect-data.csv"), "test");
     verify(sampleService, times(0)).processSampleSummary(any(CensusSurveySample.class),
-        anyListOf(CensusSampleUnit.class), eq(1));
+        anyListOf(CensusSampleUnit.class), eq(1), "test");
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -71,16 +71,16 @@ public class CsvIngesterSocialTest {
 
   @Test
   public void testBlueSky() throws Exception {
-    csvIngester.ingest(getTestFile("social-survey-sample.csv"));
+    csvIngester.ingest(getTestFile("social-survey-sample.csv"), "test");
     verify(sampleService, times(1)).processSampleSummary(any(SocialSurveySample.class),
-        anyListOf(SocialSampleUnit.class), eq(1));
+        anyListOf(SocialSampleUnit.class), eq(1), any(String.class));
   }
 
   @Test(expected = CTPException.class)
   public void missingColumns() throws Exception {
-    csvIngester.ingest(getTestFile("social-survey-sample-missing-columns.csv"));
+    csvIngester.ingest(getTestFile("social-survey-sample-missing-columns.csv"), "test");
     verify(sampleService, times(0)).processSampleSummary(any(SocialSurveySample.class),
-        anyListOf(SocialSampleUnit.class), eq(1));
+        anyListOf(SocialSampleUnit.class), eq(1), "test");
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -37,7 +37,7 @@ public class SampleEndpointIT {
         final String sampleFile = "/csv/business-survey-sample.csv";
 
         // When
-        HttpResponse<String> sampleSummaryResponse = Unirest.post("http://localhost:" + port + "/samples/B/fileupload")
+        HttpResponse<String> sampleSummaryResponse = Unirest.post("http://localhost:" + port + "/samples/B/fileupload?collectionExerciseId=test")
                 .basicAuth("admin", "secret")
                 .field("file", getClass().getResourceAsStream(sampleFile), ContentType.MULTIPART_FORM_DATA, "file")
                 .asString();

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -78,7 +78,7 @@ public class SampleEndpointUnitTest {
         MockMultipartFile file = new MockMultipartFile("file", "filename.txt".getBytes());
 
         // When
-        ResultActions actions = mockMvc.perform(fileUpload(String.format("/samples/%s/fileupload", type)).file(file));
+        ResultActions actions = mockMvc.perform(fileUpload(String.format("/samples/%s/fileupload?collectionExerciseId=test", type)).file(file));
 
         // Then
         actions.andExpect(status().isCreated());
@@ -91,7 +91,7 @@ public class SampleEndpointUnitTest {
         MockMultipartFile file = new MockMultipartFile("file", "filename.txt".getBytes());
 
         // When
-        ResultActions actions = mockMvc.perform(fileUpload(String.format("/samples/%s/fileupload", type)).file(file));
+        ResultActions actions = mockMvc.perform(fileUpload(String.format("/samples/%s/fileupload?collectionExerciseId=test", type)).file(file));
 
         // Then
         actions.andExpect(status().isBadRequest());

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
@@ -136,7 +136,7 @@ public class SampleServiceImplTest {
     BusinessSurveySample businessSample = surveySample.get(0);
     when(sampleSummaryRepository.save(any(SampleSummary.class))).then(returnsFirstArg());
 
-    sampleServiceImpl.processSampleSummary(businessSample, businessSample.getSampleUnits(), 2);
+    sampleServiceImpl.processSampleSummary(businessSample, businessSample.getSampleUnits(), 2, "test");
 
     verify(sampleSummaryRepository).save(any(SampleSummary.class));
     verify(sampleUnitRepository, times(2)).save(any(SampleUnit.class));
@@ -224,10 +224,10 @@ public class SampleServiceImplTest {
     MockMultipartFile file = new MockMultipartFile("file", "data".getBytes());
 
     // When
-    SampleSummary sampleSummary = sampleServiceImpl.ingest(file, "B");
+    SampleSummary sampleSummary = sampleServiceImpl.ingest(file, "B", "test");
 
     // Then
-    verify(csvIngesterBusiness, times(1)).ingest(file);
+    verify(csvIngesterBusiness, times(1)).ingest(file, "test");
   }
 
   @Test
@@ -236,10 +236,10 @@ public class SampleServiceImplTest {
     MockMultipartFile file = new MockMultipartFile("file", "data".getBytes());
 
     // When
-    SampleSummary sampleSummary = sampleServiceImpl.ingest(file, "b");
+    SampleSummary sampleSummary = sampleServiceImpl.ingest(file, "b", "test");
 
     // Then
-    verify(csvIngesterBusiness, times(1)).ingest(file);
+    verify(csvIngesterBusiness, times(1)).ingest(file, "test");
   }
 
   @Test(expected = UnsupportedOperationException.class)
@@ -248,7 +248,7 @@ public class SampleServiceImplTest {
     MockMultipartFile file = new MockMultipartFile("file", "data".getBytes());
 
     // When
-    sampleServiceImpl.ingest(file, "invalid-type");
+    sampleServiceImpl.ingest(file, "invalid-type", "test");
 
     // Then expect exception
   }


### PR DESCRIPTION
Receive collection exercise id in the query string for uploading a sample and post it to the party service when creating a new party

Works with other PR's
https://github.com/ONSdigital/rm-collection-exercise-service/pull/43
https://github.com/ONSdigital/ras-party/pull/119
https://github.com/ONSdigital/rm-party-service-api/pull/10
https://github.com/ONSdigital/ras-backstage/pull/87

[Trello](https://trello.com/c/nakcH70j/161-defect-r172-if-the-business-name-is-updated-in-a-sample-for-the-next-period-it-is-historically-updating-the-business-name-for-pr)

NOTE this PR will fail in travis until https://github.com/ONSdigital/rm-party-service-api/pull/10 is merged