### PR TITLE
Fix gen random UUID bug

### DIFF
--- a/src/main/resources/database/changes/release-10.49.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.0/changelog.yml
@@ -3,6 +3,9 @@ databaseChangeLog:
   - changeSet:
       id: 10.49.0-1
       author: Sarah Radford
+      validCheckSum:
+        - 7:b8f0c2df73584e8ed4e5bda477f592af
+        - 7:71c68a1a6b2db4d84c6901b471198930
       changes:
         - sqlFile:
             comment: Add uuids to sample tables

--- a/src/main/resources/database/changes/release-10.49.0/sample_add_uuids.sql
+++ b/src/main/resources/database/changes/release-10.49.0/sample_add_uuids.sql
@@ -1,5 +1,7 @@
 -- Sample schema change CTPA-1648
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- Create id columns to allow null
 ALTER TABLE sample.samplesummary ADD COLUMN id uuid;
 ALTER TABLE sample.sampleunit    ADD COLUMN id uuid;


### PR DESCRIPTION
Fixed gen_random_uuid() bug on sample service startup by modifying one of the early liquibase scripts to force the creation of the pgcrypto extension.  Also needed to add validCheckSum entries for new and old versions of script so won't break when deployed to production.