### PR TITLE
Performance Improvement

### DIFF
--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -41,6 +41,11 @@ server:
 spring:
   application:
     name: ONS SampleService
+  http:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+      file-size-threshold: 0
 
   datasource:
     driverClassName: org.postgresql.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,11 @@ spring:
       max-active: 10
       max-idle: 5
       min-idle: 3
+  http:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+      file-size-threshold: 0
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- There is a max-limit of 1MB (by default) when uploading files on
spring-boot applications. This change is required to upload MWSS sample
file with approx. 9,500 sample units.