### PR TITLE
Load a social sample file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.2</version>
+      <version>10.50.6-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.9</version>
+      <version>10.49.10-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -202,6 +202,16 @@
       <artifactId>unirest-java</artifactId>
       <version>1.4.9</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vladmihalcea</groupId>
+      <artifactId>hibernate-types-5</artifactId>
+      <version>2.2.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.6</version>
+      <version>10.50.7</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.11</version>
+      <version>10.49.14</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
       <version>1.5</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-5</artifactId>
       <version>2.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>partysvc-api</artifactId>
-      <version>10.50.6-SNAPSHOT</version>
+      <version>10.50.6</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.10-SNAPSHOT</version>
+      <version>10.49.10</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>samplesvc-api</artifactId>
-      <version>10.49.10</version>
+      <version>10.49.11</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleBeanMapper.java
@@ -6,6 +6,7 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
+import uk.gov.ons.ctp.response.sample.mapper.SampleUnitMapper;
 
 /**
  * The bean mapper to go from Entity objects to Presentation objects.
@@ -26,5 +27,6 @@ public class SampleBeanMapper extends ConfigurableMapper {
    */
   @Override
   protected final void configure(final MapperFactory factory) {
+    factory.registerMapper(new SampleUnitMapper());
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleAttributes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleAttributes.java
@@ -4,11 +4,11 @@ package uk.gov.ons.ctp.response.sample.domain.model;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.*;
 import net.sourceforge.cobertura.CoverageIgnore;
-import org.hibernate.annotations.ManyToAny;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.*;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -23,11 +23,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 @Table(name = "sampleattributes", schema = "sample")
-public class SampleAttributes {
-
-    @ManyToOne
-    @JoinColumn(name = "sampleunitfk", referencedColumnName = "id", nullable = false, insertable = false, updatable = false)
-    private SampleUnit sampleUnit;
+public class SampleAttributes implements Serializable {
 
     @Id
     @Column(name = "sampleunitfk")
@@ -36,9 +32,4 @@ public class SampleAttributes {
     @Column(name = "attributes", columnDefinition = "jsonb")
     @Type(type = "jsonb")
     private Map<String, String> attributes;
-
-    public SampleAttributes(UUID sampleUnitFK, Map<String, String> attributes) {
-        this.setSampleUnitFK(sampleUnitFK);
-        this.setAttributes(attributes);
-    }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleAttributes.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleAttributes.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ctp.response.sample.domain.model;
+
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.*;
+import net.sourceforge.cobertura.CoverageIgnore;
+import org.hibernate.annotations.ManyToAny;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.*;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Domain model object.
+ */
+@CoverageIgnore
+@Entity
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+@Table(name = "sampleattributes", schema = "sample")
+public class SampleAttributes {
+
+    @ManyToOne
+    @JoinColumn(name = "sampleunitfk", referencedColumnName = "id", nullable = false, insertable = false, updatable = false)
+    private SampleUnit sampleUnit;
+
+    @Id
+    @Column(name = "sampleunitfk")
+    private UUID sampleUnitFK;
+
+    @Column(name = "attributes", columnDefinition = "jsonb")
+    @Type(type = "jsonb")
+    private Map<String, String> attributes;
+
+    public SampleAttributes(UUID sampleUnitFK, Map<String, String> attributes) {
+        this.setSampleUnitFK(sampleUnitFK);
+        this.setAttributes(attributes);
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
@@ -1,22 +1,26 @@
 package uk.gov.ons.ctp.response.sample.domain.model;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.UUID;
-
-import javax.persistence.*;
-
-import net.sourceforge.cobertura.CoverageIgnore;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.Parameter;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import net.sourceforge.cobertura.CoverageIgnore;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.io.Serializable;
+import java.util.UUID;
 
 /**
  * Domain model object.
@@ -43,7 +47,6 @@ public class SampleUnit implements Serializable {
   private Integer sampleUnitPK;
   
   @Column(name = "id")
-  @NaturalId
   private UUID id;
 
   @Column(name = "samplesummaryfk")

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
@@ -62,7 +62,6 @@ public class SampleUnit implements Serializable {
   @Column(name = "statefk")
   private SampleUnitDTO.SampleUnitState state;
 
-  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "sampleUnit")
-  private List<SampleAttributes> sampleAttributes;
-
+  @Transient
+  private SampleAttributes sampleAttributes;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/model/SampleUnit.java
@@ -1,19 +1,14 @@
 package uk.gov.ons.ctp.response.sample.domain.model;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.UUID;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Parameter;
 
 import lombok.AccessLevel;
@@ -48,6 +43,7 @@ public class SampleUnit implements Serializable {
   private Integer sampleUnitPK;
   
   @Column(name = "id")
+  @NaturalId
   private UUID id;
 
   @Column(name = "samplesummaryfk")
@@ -65,5 +61,8 @@ public class SampleUnit implements Serializable {
   @Enumerated(EnumType.STRING)
   @Column(name = "statefk")
   private SampleUnitDTO.SampleUnitState state;
+
+  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "sampleUnit")
+  private List<SampleAttributes> sampleAttributes;
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleAttributesRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleAttributesRepository.java
@@ -4,11 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 
+import java.util.UUID;
+
 
 /**
  * JPA Data Repository needed to persist Survey SampleAttributes
  */
 @Repository
-public interface SampleAttributesRepository extends JpaRepository<SampleAttributes, Integer> {
+public interface SampleAttributesRepository extends JpaRepository<SampleAttributes, UUID> {
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleAttributesRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleAttributesRepository.java
@@ -1,0 +1,14 @@
+package uk.gov.ons.ctp.response.sample.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
+
+
+/**
+ * JPA Data Repository needed to persist Survey SampleAttributes
+ */
+@Repository
+public interface SampleAttributesRepository extends JpaRepository<SampleAttributes, Integer> {
+
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -120,6 +120,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       try {
         return Optional.of(this.sampleService.ingest(newSummary, file, type));
       } catch (Exception e) {
+        log.error("Failed to ingest sample [{}]", newSummary.getId(), e);
         return this.sampleService.failSampleSummary(newSummary, e);
       }
     };

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -106,7 +106,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
           sampleUnitList.add(parseLine(nextLine, unitRefs));
         } catch(CTPException e){
           String newMessage = String.format("Line %d: %s", csvReader.getRecordsRead(), e.getMessage());
-          throw new CTPException(e.getFault(), newMessage);
+          throw new CTPException(e.getFault(), e, newMessage);
         }
       }
       SampleSummary sampleSummaryWithCICount = sampleService.saveSample(sampleSummary, sampleUnitList, SampleUnitState.INIT);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -115,8 +115,9 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
       return sampleSummaryWithCICount;
   }
 
-  private BusinessSampleUnit parseLine(String[] nextLine, Set<String> unitRefs) throws IllegalAccessException, java.lang.reflect.InvocationTargetException, InstantiationException, java.beans.IntrospectionException, CTPException {BusinessSampleUnit businessSampleUnit = processLine(columnPositionMappingStrategy, nextLine);
-          List<String> namesOfInvalidColumns = validateLine(businessSampleUnit);
+  private BusinessSampleUnit parseLine(String[] nextLine, Set<String> unitRefs) throws IllegalAccessException, java.lang.reflect.InvocationTargetException, InstantiationException, java.beans.IntrospectionException, CTPException {
+      BusinessSampleUnit businessSampleUnit = processLine(columnPositionMappingStrategy, nextLine);
+      List<String> namesOfInvalidColumns = validateLine(businessSampleUnit);
 
       // If a unit ref is already registered
       if (unitRefs.contains(businessSampleUnit.getSampleUnitRef())) {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -14,7 +14,7 @@ import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.message.PartyPublisher;
 import uk.gov.ons.ctp.response.sample.party.PartyUtil;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
 import validation.SampleUnitBase;
@@ -76,7 +76,6 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
 
   private ColumnPositionMappingStrategy<BusinessSampleUnit> columnPositionMappingStrategy;
 
-
   /**
    * Lazy create a reusable validator
    *
@@ -110,7 +109,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
           throw new CTPException(e.getFault(), newMessage);
         }
       }
-      SampleSummary sampleSummaryWithCICount = sampleService.saveSample(sampleSummary, sampleUnitList, SampleUnitDTO.SampleUnitState.INIT);
+      SampleSummary sampleSummaryWithCICount = sampleService.saveSample(sampleSummary, sampleUnitList, SampleUnitState.INIT);
       publishToPartyQueue(sampleUnitList, sampleSummary.getId().toString());
 
       return sampleSummaryWithCICount;
@@ -121,7 +120,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
 
       // If a unit ref is already registered
       if (unitRefs.contains(businessSampleUnit.getSampleUnitRef())) {
-        log.error("This sample unit ref {} is duplicated in the file.", businessSampleUnit.getSampleUnitRef());
+        log.warn("This sample unit ref {} is duplicated in the file.", businessSampleUnit.getSampleUnitRef());
         throw new CTPException(CTPException.Fault.VALIDATION_FAILED,
                 String.format("This sample unit ref %s is duplicated in the file.", businessSampleUnit.getSampleUnitRef()));
       }
@@ -130,7 +129,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
           if (!namesOfInvalidColumns.isEmpty()) {
             String errorMessage = String.format("Error in %s due to field(s) %s", Arrays.toString(nextLine),
                     Arrays.toString(namesOfInvalidColumns.toArray()));
-            log.error(errorMessage);
+            log.warn(errorMessage);
             throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMessage);
           }
           businessSampleUnit.setSampleUnitType("B");

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -14,8 +14,8 @@ import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.message.PartyPublisher;
 import uk.gov.ons.ctp.response.sample.party.PartyUtil;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
-import uk.gov.ons.ctp.response.sample.service.impl.SampleServiceImpl;
 import validation.BusinessSampleUnit;
 import validation.SampleUnitBase;
 
@@ -105,7 +105,7 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
           throw new CTPException(e.getFault(), newMessage);
         }
       }
-      SampleSummary sampleSummaryWithCICount = sampleService.saveSample(sampleSummary, sampleUnitList);
+      SampleSummary sampleSummaryWithCICount = sampleService.saveSample(sampleSummary, sampleUnitList, SampleUnitDTO.SampleUnitState.INIT);
       publishToPartyQueue(sampleUnitList, sampleSummary.getId().toString());
 
       return sampleSummaryWithCICount;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -24,7 +24,12 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import java.io.InputStreamReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
 
@@ -108,7 +108,7 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
 
       }
 
-      return sampleService.saveSample(sampleSummary, samplingUnitList, SampleUnitDTO.SampleUnitState.INIT);
+      return sampleService.saveSample(sampleSummary, samplingUnitList, SampleUnitState.INIT);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -12,7 +12,6 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
-import validation.CensusSurveySample;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -108,7 +107,7 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
 
       }
 
-      return sampleService.processSampleSummary(sampleSummary, samplingUnitList);
+      return sampleService.saveSample(sampleSummary, samplingUnitList);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
 
@@ -107,7 +108,7 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
 
       }
 
-      return sampleService.saveSample(sampleSummary, samplingUnitList);
+      return sampleService.saveSample(sampleSummary, samplingUnitList, SampleUnitDTO.SampleUnitState.INIT);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -1,99 +1,88 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
-import liquibase.util.csv.opencsv.CSVReader;
-import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
+import com.google.common.collect.Sets;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
-import validation.SocialSurveySample;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
 
-  private static final String SAMPLEUNITREF = "sampleUnitRef";
-  private static final String FORMTYPE = "formType";
+    @Autowired
+    private SampleService sampleService;
 
-  private static final String[] COLUMNS = new String[] {SAMPLEUNITREF, FORMTYPE};
+    @Autowired
+    private SampleAttributesRepository sampleAttributesRepository;
+    private SampleUnitRepository sampleUnitRepository;
 
-  @Autowired
-  private SampleService sampleService;
+    @Transactional(propagation = Propagation.REQUIRED)
+    public SampleSummary ingest(final SampleSummary sampleSummary, final MultipartFile file)
+            throws Exception {
 
-  private ColumnPositionMappingStrategy<SocialSampleUnit> columnPositionMappingStrategy;
+        List<SocialSampleUnit> socialSamples = new ArrayList<>();
+        List<SampleAttributes> sampleAttributes = new ArrayList<>();
 
-  /**
-   * Lazy create a reusable validator
-   *
-   * @return the cached validator
-   */
-  @Cacheable(cacheNames = "csvIngestValidator")
-  private Validator getValidator() {
-    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-    return factory.getValidator();
-  }
+        try (CSVParser parser = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(new InputStreamReader(file.getInputStream()))) {
+            Set<String> headers = parser.getHeaderMap().keySet();
+            validateHeaders(headers);
 
-  public CsvIngesterSocial() {
-    columnPositionMappingStrategy = new ColumnPositionMappingStrategy<>();
-    columnPositionMappingStrategy.setType(SocialSampleUnit.class);
-    columnPositionMappingStrategy.setColumnMapping(COLUMNS);
-  }
+            for (CSVRecord line : parser) {
+                SocialSampleUnit socialSampleUnit = parseLine(line);
+                socialSamples.add(socialSampleUnit);
 
-  public SampleSummary ingest(final SampleSummary sampleSummary, final MultipartFile file)
-      throws Exception {
+                sampleAttributes.add(new SampleAttributes(socialSampleUnit.getSampleUnitId(), socialSampleUnit.getAttributes()));
+            }
+        }
 
-    CSVReader csvReader = new CSVReader(new InputStreamReader(file.getInputStream()), ':');
-    String[] nextLine;
-    List<SocialSampleUnit> samplingUnitList = new ArrayList<>();
+        // TODO social sample units need to have state set to PERSISTED
+        sampleService.saveSample(sampleSummary, socialSamples);
+        sampleAttributesRepository.save(sampleAttributes);
+        sampleService.activateSampleSummaryState(sampleSummary.getSampleSummaryPK());
 
-      while((nextLine = csvReader.readNext()) != null) {
+        return sampleSummary;
+    }
 
-          SocialSampleUnit businessSampleUnit = processLine(columnPositionMappingStrategy, nextLine);
-          Optional<String> namesOfInvalidColumns = validateLine(businessSampleUnit);
-          if (namesOfInvalidColumns.isPresent()) {
-            log.error("Problem parsing line {} due to {} - entire ingest aborted", Arrays.toString(nextLine),
-                namesOfInvalidColumns.get());
-            throw new CTPException(CTPException.Fault.VALIDATION_FAILED, String.format("Problem parsing line %s due to %s", Arrays.toString(nextLine),
-                namesOfInvalidColumns.get()));
-          }
-          
-          samplingUnitList.add(businessSampleUnit);
+    private SocialSampleUnit parseLine(CSVRecord line) throws CTPException{
+        SocialSampleUnit sampleUnit = new SocialSampleUnit();
+        sampleUnit.setAttributes(line.toMap());
+        List<String> invalidColumns = sampleUnit.validate();
+        if (!invalidColumns.isEmpty()) {
+            String errorMessage = String.format("Error in row [%s] due to missing field(s) [%s]", StringUtils.join(line.toMap().values(), ","),
+                    StringUtils.join(invalidColumns, ","));
+            log.error(errorMessage);
+            throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMessage);
+        }
+        return sampleUnit;
+    }
 
-      }
-
-      return sampleService.processSampleSummary(sampleSummary, samplingUnitList);
-  }
-
-  /**
-   * validate the csv line and return the optional concatenated list of fields
-   * failing validation
-   *
-   * @param csvLine the line
-   * @return the errored column names separated by '_'
-   */
-  private Optional<String> validateLine(SocialSampleUnit csvLine) {
-    Set<ConstraintViolation<SocialSampleUnit>> violations = getValidator().validate(csvLine);
-    String invalidColumns = violations.stream().map(v -> v.getPropertyPath().toString())
-        .collect(Collectors.joining("_"));
-    return (invalidColumns.length() == 0) ? Optional.empty() : Optional.ofNullable(invalidColumns);
-  }
+    private void validateHeaders(Set<String> headers) throws CTPException{
+        Set<String> missingRequriedHeaders = Sets.difference(SocialSampleUnit.REQUIRED_ATTRIBUTES, headers);
+        if (!missingRequriedHeaders.isEmpty()){
+            String errorMessage = String.format("Error in header row, missing required header(s) [%s]", StringUtils.join(missingRequriedHeaders, ","));
+            log.error(errorMessage);
+            throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMessage);
+        }
+    }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -24,6 +24,7 @@ import validation.SocialSampleUnit;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -42,7 +44,9 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
         List<SocialSampleUnit> socialSamples = new ArrayList<>();
         List<SampleAttributes> sampleAttributes = new ArrayList<>();
 
-        try (CSVParser parser = CSVFormat.RFC4180.withFirstRecordAsHeader().parse(new InputStreamReader(file.getInputStream()))) {
+        final Reader reader = new InputStreamReader(new BOMInputStream(file.getInputStream()));
+
+        try (CSVParser parser = CSVParser.parse(reader, CSVFormat.RFC4180.withFirstRecordAsHeader().withIgnoreSurroundingSpaces())) {
             Set<String> headers = parser.getHeaderMap().keySet();
             validateHeaders(headers);
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -56,7 +56,6 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
             }
         }
 
-        // TODO social sample units need to have state set to PERSISTED
         sampleService.saveSample(sampleSummary, socialSamples, SampleUnitDTO.SampleUnitState.PERSISTED);
         sampleAttributesRepository.save(sampleAttributes);
         sampleService.activateSampleSummaryState(sampleSummary.getSampleSummaryPK());

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -17,7 +17,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
@@ -58,7 +58,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
             }
         }
 
-        sampleService.saveSample(sampleSummary, socialSamples, SampleUnitDTO.SampleUnitState.PERSISTED);
+        sampleService.saveSample(sampleSummary, socialSamples, SampleUnitState.PERSISTED);
         sampleAttributesRepository.save(sampleAttributes);
         sampleService.activateSampleSummaryState(sampleSummary.getSampleSummaryPK());
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -17,6 +17,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
@@ -56,7 +57,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
         }
 
         // TODO social sample units need to have state set to PERSISTED
-        sampleService.saveSample(sampleSummary, socialSamples);
+        sampleService.saveSample(sampleSummary, socialSamples, SampleUnitDTO.SampleUnitState.PERSISTED);
         sampleAttributesRepository.save(sampleAttributes);
         sampleService.activateSampleSummaryState(sampleSummary.getSampleSummaryPK());
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -35,7 +35,6 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
 
     @Autowired
     private SampleAttributesRepository sampleAttributesRepository;
-    private SampleUnitRepository sampleUnitRepository;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public SampleSummary ingest(final SampleSummary sampleSummary, final MultipartFile file)
@@ -70,7 +69,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
         if (!invalidColumns.isEmpty()) {
             String errorMessage = String.format("Error in row [%s] due to missing field(s) [%s]", StringUtils.join(line.toMap().values(), ","),
                     StringUtils.join(invalidColumns, ","));
-            log.error(errorMessage);
+            log.warn(errorMessage);
             throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMessage);
         }
         return sampleUnit;
@@ -80,7 +79,7 @@ public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
         Set<String> missingRequriedHeaders = Sets.difference(SocialSampleUnit.REQUIRED_ATTRIBUTES, headers);
         if (!missingRequriedHeaders.isEmpty()){
             String errorMessage = String.format("Error in header row, missing required header(s) [%s]", StringUtils.join(missingRequriedHeaders, ","));
-            log.error(errorMessage);
+            log.warn(errorMessage);
             throw new CTPException(CTPException.Fault.VALIDATION_FAILED, errorMessage);
         }
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -16,7 +16,6 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
-import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.ons.ctp.response.sample.mapper;
+
+import ma.glasnost.orika.CustomMapper;
+import ma.glasnost.orika.MappingContext;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
+
+public class SampleUnitMapper extends CustomMapper<SampleUnit, uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit> {
+
+    @Override
+    public void mapAtoB(SampleUnit sampleUnit, uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit sampleUnit2, MappingContext context) {
+        sampleUnit2.setFormType(sampleUnit.getFormType());
+        sampleUnit2.setSampleUnitRef(sampleUnit.getSampleUnitRef());
+        sampleUnit2.setSampleUnitType(sampleUnit.getSampleUnitType());
+        if (sampleUnit.getSampleAttributes() != null) {
+            uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes.Builder<Void> builder =
+                    new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes().newCopyBuilder();
+            sampleUnit.getSampleAttributes().get(0).getAttributes().forEach((k, v) -> builder.addEntries().withKey(k).withValue(v));
+            sampleUnit2.setSampleAttributes(builder.build());
+        }
+    }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
@@ -14,7 +14,7 @@ public class SampleUnitMapper extends CustomMapper<SampleUnit, uk.gov.ons.ctp.re
         if (sampleUnit.getSampleAttributes() != null) {
             uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes.Builder<Void> builder =
                     new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes().newCopyBuilder();
-            sampleUnit.getSampleAttributes().get(0).getAttributes().forEach((k, v) -> builder.addEntries().withKey(k).withValue(v));
+            sampleUnit.getSampleAttributes().getAttributes().forEach((k, v) -> builder.addEntries().withKey(k).withValue(v));
             sampleUnit2.setSampleAttributes(builder.build());
         }
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapper.java
@@ -2,18 +2,19 @@ package uk.gov.ons.ctp.response.sample.mapper;
 
 import ma.glasnost.orika.CustomMapper;
 import ma.glasnost.orika.MappingContext;
-import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
+import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
-public class SampleUnitMapper extends CustomMapper<SampleUnit, uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit> {
+
+public class SampleUnitMapper extends CustomMapper<uk.gov.ons.ctp.response.sample.domain.model.SampleUnit, SampleUnit> {
 
     @Override
-    public void mapAtoB(SampleUnit sampleUnit, uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit sampleUnit2, MappingContext context) {
+    public void mapAtoB(uk.gov.ons.ctp.response.sample.domain.model.SampleUnit sampleUnit, SampleUnit sampleUnit2, MappingContext context) {
         sampleUnit2.setFormType(sampleUnit.getFormType());
         sampleUnit2.setSampleUnitRef(sampleUnit.getSampleUnitRef());
         sampleUnit2.setSampleUnitType(sampleUnit.getSampleUnitType());
         if (sampleUnit.getSampleAttributes() != null) {
-            uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes.Builder<Void> builder =
-                    new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes().newCopyBuilder();
+           SampleUnit.SampleAttributes.Builder<Void> builder =
+                    new SampleUnit.SampleAttributes().newCopyBuilder();
             sampleUnit.getSampleAttributes().getAttributes().forEach((k, v) -> builder.addEntries().withKey(k).withValue(v));
             sampleUnit2.setSampleAttributes(builder.build());
         }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -22,6 +22,8 @@ import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
+import javax.transaction.Transactional;
+
 /**
  * Distributes SampleUnits
  */
@@ -58,6 +60,7 @@ public class SampleUnitDistributor {
   /**
    * @return SampleUnitDistributionInfo Information for SampelUnit Distribution
    */
+  @Transactional
   public final SampleUnitDistributionInfo distribute() {
     log.info("SampleUnitDistributor is in the house");
     SampleUnitDistributionInfo distInfo = new SampleUnitDistributionInfo();

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -11,7 +11,6 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
-import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
@@ -19,6 +18,7 @@ import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes;
 
 import javax.transaction.Transactional;
 import java.util.List;
@@ -97,7 +97,7 @@ public class SampleUnitDistributor {
           try {
             uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit mappedSampleUnit = mapperFacade.map(sampleUnit,
                 uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.class);
-            SampleAttributes sampleAttributes = sampleAttributesRepository.findOne(sampleUnit.getId());
+            uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes sampleAttributes = sampleAttributesRepository.findOne(sampleUnit.getId());
             if (sampleAttributes != null) {
               mappedSampleUnit.setSampleAttributes(mapSampleAttributes(sampleAttributes));
             }
@@ -131,9 +131,9 @@ public class SampleUnitDistributor {
     return distInfo;
   }
 
-  private uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes mapSampleAttributes(SampleAttributes sampleAttributes) {
-    uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes mappedSampleAttributes = new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes();
-    uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes.Builder<Void> sampleAttributesBuilder = mappedSampleAttributes.newCopyBuilder();
+  private SampleAttributes mapSampleAttributes(uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes sampleAttributes) {
+    SampleAttributes mappedSampleAttributes = new SampleAttributes();
+    SampleAttributes.Builder<Void> sampleAttributesBuilder = mappedSampleAttributes.newCopyBuilder();
     for (Map.Entry<String, String> attribute : sampleAttributes.getAttributes().entrySet()) {
       sampleAttributesBuilder.addEntries().withKey(attribute.getKey()).withValue(attribute.getValue());
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -1,28 +1,29 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import lombok.extern.slf4j.Slf4j;
+import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import lombok.extern.slf4j.Slf4j;
-import ma.glasnost.orika.MapperFacade;
 import uk.gov.ons.ctp.common.distributed.DistributedListManager;
 import uk.gov.ons.ctp.common.distributed.LockingException;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRepository;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Distributes SampleUnits
@@ -39,6 +40,9 @@ public class SampleUnitDistributor {
 
   @Autowired
   private SampleUnitRepository sampleUnitRepository;
+
+  @Autowired
+  private SampleAttributesRepository sampleAttributesRepository;
 
   @Autowired
   private AppConfig appConfig;
@@ -61,7 +65,7 @@ public class SampleUnitDistributor {
    * @return SampleUnitDistributionInfo Information for SampelUnit Distribution
    */
   @Transactional
-  public final SampleUnitDistributionInfo distribute() {
+  public SampleUnitDistributionInfo distribute() {
     log.info("SampleUnitDistributor is in the house");
     SampleUnitDistributionInfo distInfo = new SampleUnitDistributionInfo();
 
@@ -84,7 +88,7 @@ public class SampleUnitDistributor {
 
         if (sampleUnits.size() > 0) {
           sampleUnitDistributionListManager.saveList(SAMPLEUNIT_DISTRIBUTOR_LIST_ID, sampleUnits.stream()
-              .map(su -> su.getSampleUnitPK())
+              .map(SampleUnit::getSampleUnitPK)
               .collect(Collectors.toList()), true);
         }
 
@@ -93,8 +97,13 @@ public class SampleUnitDistributor {
           try {
             uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit mappedSampleUnit = mapperFacade.map(sampleUnit,
                 uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.class);
+            SampleAttributes sampleAttributes = sampleAttributesRepository.findOne(sampleUnit.getId());
+            if (sampleAttributes != null) {
+              mappedSampleUnit.setSampleAttributes(mapSampleAttributes(sampleAttributes));
+            }
             mappedSampleUnit.setCollectionExerciseId(job.getCollectionExerciseId().toString());
             sendSampleUnitToCollectionExerciseQueue(sampleUnit, mappedSampleUnit);
+
             successes++;
           } catch (CTPException e) {
             // single case/questionnaire db changes rolled back
@@ -112,7 +121,7 @@ public class SampleUnitDistributor {
         }
       }
     } catch (Exception e) {
-      log.error("Failed to process sample units because {}", e);
+      log.error("Failed to process sample units", e);
     }
 
     distInfo.setSampleUnitsSucceeded(successes);
@@ -120,6 +129,15 @@ public class SampleUnitDistributor {
 
     log.info("SampleUnitsDistributor sleeping");
     return distInfo;
+  }
+
+  private uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes mapSampleAttributes(SampleAttributes sampleAttributes) {
+    uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes mappedSampleAttributes = new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes();
+    uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit.SampleAttributes.Builder<Void> sampleAttributesBuilder = mappedSampleAttributes.newCopyBuilder();
+    for (Map.Entry<String, String> attribute : sampleAttributes.getAttributes().entrySet()) {
+      sampleAttributesBuilder.addEntries().withKey(attribute.getKey()).withValue(attribute.getValue());
+    }
+    return sampleAttributesBuilder.build();
   }
 
   /**
@@ -131,25 +149,17 @@ public class SampleUnitDistributor {
    */
   private void sendSampleUnitToCollectionExerciseQueue(SampleUnit sampleUnit,
       uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit mappedSampleUnit) throws CTPException {
-    transitionSampleUnitStateFromDeliveryEvent(sampleUnit.getSampleUnitPK());
+    transitionSampleUnitStateFromDeliveryEvent(sampleUnit);
     sampleUnitPublisher.send(mappedSampleUnit);
   }
 
-  /**
-   * Transitions SampleUnit State from Delivery Event
-   *
-   * @param sampleUnitPK sample unit primary key
-   * @return SampleUnit the target sampleunit
-   * @throws CTPException if transition issue
-   */
-  public SampleUnit transitionSampleUnitStateFromDeliveryEvent(Integer sampleUnitPK) throws CTPException {
-    SampleUnit targetSampleUnit = sampleUnitRepository.findOne(sampleUnitPK);
+  private SampleUnit transitionSampleUnitStateFromDeliveryEvent(SampleUnit sampleUnit) throws CTPException {
     SampleUnitDTO.SampleUnitState newState = sampleUnitStateTransitionManager.transition(
-        targetSampleUnit.getState(),
+        sampleUnit.getState(),
         SampleUnitDTO.SampleUnitEvent.DELIVERING);
-    targetSampleUnit.setState(newState);
-    sampleUnitRepository.saveAndFlush(targetSampleUnit);
-    return targetSampleUnit;
+    sampleUnit.setState(newState);
+    sampleUnitRepository.saveAndFlush(sampleUnit);
+    return sampleUnit;
   }
 
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
@@ -40,7 +41,7 @@ public interface SampleService {
    * @param sampleSummary the sample summary being processed
    * @param samplingUnitList list of sampling units.
    */
-  SampleSummary processSampleSummary(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList);
+  SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList);
 
   /**
    * Create a new sample summary and persist to the database

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -7,7 +7,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import validation.SampleUnitBase;
 
 import java.util.List;
@@ -39,7 +39,7 @@ public interface SampleService {
    * @param samplingUnitList list of sampling units.
    * @param sampleUnitState
    */
-  SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList, SampleUnitDTO.SampleUnitState sampleUnitState);
+  SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList, SampleUnitState sampleUnitState);
 
   /**
    * Create a new sample summary and persist to the database

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -1,20 +1,18 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
-import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import validation.SampleUnitBase;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Future;
 
 /**
  * The SampleService interface defines all business behaviours for operations on the Sample entity model.
@@ -37,11 +35,11 @@ public interface SampleService {
 
   /**
    * Create and save a SampleSummary from the incoming SurveySample
-   *
-   * @param sampleSummary the sample summary being processed
+   *  @param sampleSummary the sample summary being processed
    * @param samplingUnitList list of sampling units.
+   * @param sampleUnitState
    */
-  SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList);
+  SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList, SampleUnitDTO.SampleUnitState sampleUnitState);
 
   /**
    * Create a new sample summary and persist to the database

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java
@@ -14,7 +14,6 @@ import uk.gov.ons.ctp.common.time.DateTimeUtil;
 import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
-import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
@@ -95,13 +94,13 @@ public class SampleServiceImpl implements SampleService {
 
   @Override
   @Transactional(propagation = Propagation.REQUIRED)
-  public SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList) {
+  public SampleSummary saveSample(SampleSummary sampleSummary, List<? extends SampleUnitBase> samplingUnitList, SampleUnitDTO.SampleUnitState sampleUnitState) {
     int expectedCI = calculateExpectedCollectionInstruments(samplingUnitList);
 
     sampleSummary.setTotalSampleUnits(samplingUnitList.size());
     sampleSummary.setExpectedCollectionInstruments(expectedCI);
     SampleSummary savedSampleSummary = sampleSummaryRepository.save(sampleSummary);
-    saveSampleUnits(samplingUnitList, savedSampleSummary);
+    saveSampleUnits(samplingUnitList, savedSampleSummary, sampleUnitState);
 
     return savedSampleSummary;
   }
@@ -126,14 +125,14 @@ public class SampleServiceImpl implements SampleService {
     return sampleSummaryRepository.save(sampleSummary);
   }
 
-  private void saveSampleUnits(List<? extends SampleUnitBase> samplingUnitList, SampleSummary sampleSummary) {
+  private void saveSampleUnits(List<? extends SampleUnitBase> samplingUnitList, SampleSummary sampleSummary, SampleUnitDTO.SampleUnitState sampleUnitState) {
     for (SampleUnitBase sampleUnitBase : samplingUnitList) {
       SampleUnit sampleUnit = new SampleUnit();
       sampleUnit.setSampleSummaryFK(sampleSummary.getSampleSummaryPK());
       sampleUnit.setSampleUnitRef(sampleUnitBase.getSampleUnitRef());
       sampleUnit.setSampleUnitType(sampleUnitBase.getSampleUnitType());
       sampleUnit.setFormType(sampleUnitBase.getFormType());
-      sampleUnit.setState(SampleUnitDTO.SampleUnitState.INIT);
+      sampleUnit.setState(sampleUnitState);
       sampleUnit.setId(sampleUnitBase.getSampleUnitId());
       eventPublisher.publishEvent("Sample Init");
       sampleUnitRepository.save(sampleUnit);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,4 +7,3 @@ spring:
     schema: classpath:/schema.sql
     username: postgres
     password: postgres
-

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,3 +7,6 @@ spring:
     schema: classpath:/schema.sql
     username: postgres
     password: postgres
+
+sample-unit-distribution:
+  delay-milli-seconds: 1000

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -13,4 +13,6 @@ databaseChangeLog:
   - include:
       file: database/changes/release-10.46.0/changelog.yml
   - include:
-      file: database/changes/release-10.49.0/changelog.yml 
+      file: database/changes/release-10.49.0/changelog.yml
+  - include:
+      file: database/changes/release-10.49.1/changelog.yml

--- a/src/main/resources/database/changes/release-10.49.1/add_sample_attributes_table.sql
+++ b/src/main/resources/database/changes/release-10.49.1/add_sample_attributes_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE sample.sampleattributes
+(
+  sampleunitfk UUID PRIMARY KEY REFERENCES sample.sampleunit(id),
+  attributes JSONB NOT NULL
+);

--- a/src/main/resources/database/changes/release-10.49.1/changelog.yml
+++ b/src/main/resources/database/changes/release-10.49.1/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.49.1-1
+      author: Adam Hawtin
+      changes:
+        - sqlFile:
+            comment: Add sample attributes table
+            path: add_sample_attributes_table.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/sample/TestFiles.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/TestFiles.java
@@ -8,14 +8,6 @@ import java.nio.file.Paths;
 
 public class TestFiles {
 
-    /**
-     * take a named test file and create a copy of it - is because the ingester
-     * will delete the source csv file after ingest
-     *
-     * @param fileName source file name
-     * @return the newly created file
-     * @throws Exception oops
-     */
     public static MockMultipartFile getTestFile(String fileName) throws Exception {
         Path csvFileLocation = Paths.get(TestFiles.class.getClassLoader().getResource("csv/" + fileName).toURI());
         return new MockMultipartFile("file", fileName, "csv",

--- a/src/test/java/uk/gov/ons/ctp/response/sample/TestFiles.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/TestFiles.java
@@ -1,0 +1,29 @@
+package uk.gov.ons.ctp.response.sample;
+
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestFiles {
+
+    /**
+     * take a named test file and create a copy of it - is because the ingester
+     * will delete the source csv file after ingest
+     *
+     * @param fileName source file name
+     * @return the newly created file
+     * @throws Exception oops
+     */
+    public static MockMultipartFile getTestFile(String fileName) throws Exception {
+        Path csvFileLocation = Paths.get(TestFiles.class.getClassLoader().getResource("csv/" + fileName).toURI());
+        return new MockMultipartFile("file", fileName, "csv",
+                Files.readAllBytes(csvFileLocation));
+    }
+
+    public static MockMultipartFile getTestFileFromString(String content) {
+        return new MockMultipartFile("file", "fileName", "csv",
+                content.getBytes());
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/sample/Unirest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/Unirest.java
@@ -1,0 +1,31 @@
+package uk.gov.ons.ctp.response.sample;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+
+public class Unirest {
+
+    public static void initialiseUnirest() {
+        com.mashape.unirest.http.Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {
+            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+                    = new com.fasterxml.jackson.databind.ObjectMapper();
+
+            public <T> T readValue(String value, Class<T> valueType) {
+                try {
+                    return jacksonObjectMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            public String writeValue(Object value) {
+                try {
+                    return jacksonObjectMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/sample/UnirestInitialiser.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/UnirestInitialiser.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.IOException;
 
-public class Unirest {
+public class UnirestInitialiser {
 
     public static void initialiseUnirest() {
         com.mashape.unirest.http.Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -1,29 +1,29 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
-import javassist.tools.rmi.Sample;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockMultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
+import uk.gov.ons.ctp.response.sample.TestFiles;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterBusiness;
+import uk.gov.ons.ctp.response.sample.message.PartyPublisher;
+import uk.gov.ons.ctp.response.sample.party.PartyUtil;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
-import validation.BusinessSurveySample;
+import validation.SampleUnitBase;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
@@ -47,6 +47,12 @@ public class CsvIngesterBusinessTest {
 
   @Mock
   private SampleService sampleService;
+
+  @Mock
+  private PartyPublisher partyPublisher;
+
+  @Captor
+  public ArgumentCaptor<List<BusinessSampleUnit>> argumentCaptor;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -102,34 +108,59 @@ public class CsvIngesterBusinessTest {
   }
 
   @Test
-  public void testBlueSky() throws Exception {
+  public void testIngestBusinessSampleSuccess() throws Exception {
+    // Given
     SampleSummary sampleSummary = new SampleSummary();
-    csvIngester.ingest(sampleSummary, getTestFile("business-survey-sample.csv"));
-    verify(sampleService, times(1)).processSampleSummary(eq(sampleSummary),
+    sampleSummary.setId(UUID.randomUUID());
+    BusinessSampleUnit businessSampleUnit = createBusinessSampleUnit();
+    given(sampleService.saveSample(sampleSummary, Collections.singletonList(businessSampleUnit))).willReturn(sampleSummary);
+
+    // When
+    csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));
+
+    // Then
+    verify(sampleService, times(1)).saveSample(eq(sampleSummary),
         anyListOf(BusinessSampleUnit.class));
   }
 
   @Test
-  public void testMultipleLines() throws Exception {
+  public void testParseMultipleLinesFromBusinessSampleFile() throws Exception {
+    // Given
     SampleSummary sampleSummary = new SampleSummary();
-    csvIngester.ingest(sampleSummary, getTestFile("business-survey-sample-multiple.csv"));
-    verify(sampleService, times(1)).processSampleSummary(eq(sampleSummary),
+    sampleSummary.setId(UUID.randomUUID());
+    given(sampleService.saveSample(any(), any())).willReturn(sampleSummary);
+
+    // When
+    csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample-multiple.csv"));
+
+    // Then
+    verify(sampleService, times(1)).saveSample(eq(sampleSummary),
             anyListOf(BusinessSampleUnit.class));
   }
 
   @Test(expected = CTPException.class)
-  public void testDate() throws Exception {
+  public void testParseDateFromSampleSummary() throws Exception {
+    // Given
     SampleSummary sampleSummary = new SampleSummary();
-    csvIngester.ingest(sampleSummary, getTestFile("business-survey-sample-date.csv"));
-    verify(sampleService, times(0)).processSampleSummary(eq(sampleSummary),
+
+    // When
+    csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample-date.csv"));
+
+    // Then
+    verify(sampleService, times(0)).saveSample(eq(sampleSummary),
         anyListOf(BusinessSampleUnit.class));
   }
 
   @Test(expected = CTPException.class)
   public void testMissingColumns() throws Exception {
+    // Given
     SampleSummary sampleSummary = new SampleSummary();
-    csvIngester.ingest(sampleSummary, getTestFile("business-survey-sample-missing-columns.csv"));
-    verify(sampleService, times(0)).processSampleSummary(eq(sampleSummary),
+
+    // When
+    csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample-missing-columns.csv"));
+
+    // Then
+    verify(sampleService, times(0)).saveSample(eq(sampleSummary),
             anyListOf(BusinessSampleUnit.class));
     thrown.expect(CTPException.class);
   }
@@ -170,10 +201,71 @@ public class CsvIngesterBusinessTest {
 
   @Test(expected = CTPException.class)
   public void ensureNoDuplicateUnitRef() throws Exception {
+    // Given
     SampleSummary sampleSummary = new SampleSummary();
-    MockMultipartFile f = getTestFile("business-survey-duplicate-unitrefs.csv");
+    MockMultipartFile f = TestFiles.getTestFile("business-survey-duplicate-unitrefs.csv");
 
+    // When
     csvIngester.ingest(sampleSummary, f);
+
+    // Then
+    verify(sampleService, times(0)).saveSample(eq(sampleSummary),
+            anyListOf(BusinessSampleUnit.class));
+    thrown.expect(CTPException.class);
+  }
+
+  @Test
+  public void testPartyIsPublishedForValidSampleFile() throws Exception {
+    // Given
+    SampleSummary sampleSummary = new SampleSummary();
+    sampleSummary.setId(UUID.randomUUID());
+    given(sampleService.saveSample(any(), argumentCaptor.capture())).willReturn(sampleSummary);
+
+    // When
+    csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));
+
+    // Then
+    BusinessSampleUnit capturedBusinessSampleUnit = argumentCaptor.getValue().get(0);
+    BusinessSampleUnit businessSampleUnit = createBusinessSampleUnit();
+    businessSampleUnit.setSampleUnitId(capturedBusinessSampleUnit.getSampleUnitId());
+    PartyCreationRequestDTO party = PartyUtil.convertToParty(businessSampleUnit);
+    party.getAttributes().setSampleUnitId(businessSampleUnit.getSampleUnitId().toString());
+    party.setSampleSummaryId(sampleSummary.getId().toString());
+    verify(partyPublisher).publish(party);
+
+  }
+
+  private BusinessSampleUnit createBusinessSampleUnit() {
+    BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
+    businessSampleUnit.setSampleUnitType("B");
+    businessSampleUnit.setSampleUnitRef("49900000001");
+    businessSampleUnit.setCheckletter("F");
+    businessSampleUnit.setFrosic92("50300");
+    businessSampleUnit.setRusic92("50300");
+    businessSampleUnit.setFrosic2007("45320");
+    businessSampleUnit.setRusic2007("45320");
+    businessSampleUnit.setFroempment("8478");
+    businessSampleUnit.setFrotover("801325");
+    businessSampleUnit.setEntref("9900000576");
+    businessSampleUnit.setLegalstatus("1");
+    businessSampleUnit.setEntrepmkr("E");
+    businessSampleUnit.setRegion("FE");
+    businessSampleUnit.setBirthdate("01/09/1993");
+    businessSampleUnit.setEntname1("ENTNAME1_COMPANY1");
+    businessSampleUnit.setEntname2("ENTNAME2_COMPANY1");
+    businessSampleUnit.setEntname3("");
+    businessSampleUnit.setRuname1("RUNAME1_COMPANY1");
+    businessSampleUnit.setRuname2("RUNNAME2_COMPANY1");
+    businessSampleUnit.setRuname3("");
+    businessSampleUnit.setTradstyle1("TOTAL UK ACTIVITY");
+    businessSampleUnit.setTradstyle2("");
+    businessSampleUnit.setTradstyle3("");
+    businessSampleUnit.setSeltype("C");
+    businessSampleUnit.setInclexcl("D");
+    businessSampleUnit.setCell_no("7");
+    businessSampleUnit.setFormType("15");
+    businessSampleUnit.setCurrency("S");
+    return businessSampleUnit;
   }
 
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ctp.response.sample.TestFiles.getTestFileFromString;
 
 /**
  * Test the CsvIngester distributor
@@ -46,9 +47,6 @@ public class CsvIngesterBusinessTest {
   @InjectMocks
   private CsvIngesterBusiness csvIngester;
 
-  @InjectMocks
-  private SampleEndpoint sampleEndpoint;
-
   @Mock
   private SampleService sampleService;
 
@@ -61,55 +59,6 @@ public class CsvIngesterBusinessTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  private static final String SAMPLEUNITREF = "1234567890";
-  private static final String SAMPLEUNITTYPE = "B";
-  private static final String FORMTYPE1 = "0015";
-  private static final String CHECKLETTER = "F";
-  private static final String FROSIC92 = "50300";
-  private static final String RUSIC92 = "50300";
-  private static final String FROSIC2007 = "45320";
-  private static final String RUSIC2007 = "45320";
-  private static final String FROEMPMENT = "8478";
-  private static final String FROTOVER = "801325";
-  private static final String ENTREF = "9900000576";
-  private static final String LEGALSTATUS = "1";
-  private static final String ENTREPMKR = "E";
-  private static final String REGION = "FE";
-  private static final String BIRTHDATE = "01/09/1993";
-  private static final String ENTNAME1 = "ENTNAME1_COMPANY1";
-  private static final String ENTNAME2 = "ENTNAME2_COMPANY1";
-  private static final String ENTNAME3 = "ENTNAME3_COMPANY1";
-  private static final String RUNAME1 = "RUNAME1_COMPANY1";
-  private static final String RUNAME2 = "RUNAME2_COMPANY1";
-  private static final String RUNAME3 = "RUNAME3_COMPANY1";
-  private static final String TRADSTYLE1 = "TOTAL UK ACTIVITY";
-  private static final String TRADSTYLE2 = "TRADSTYLE2_COMPANY1";
-  private static final String TRADSTYLE3 = "TRADSTYLE3_COMPANY1";
-  private static final String SELTYPE = "C";
-  private static final String INCLEXCL = "D";
-  private static final String CELLNO = "7";
-  private static final String FORMTYPE = "15";
-  private static final String CURRENCY = "S";
-
-  /**
-   * take a named test file and create a copy of it - is because the ingester
-   * will delete the source csv file after ingest
-   *
-   * @param fileName source file name
-   * @return the newly created file
-   * @throws Exception oops
-   */
-  private MockMultipartFile getTestFile(String fileName) throws Exception {
-    Path csvFileLocation = Paths.get(getClass().getClassLoader().getResource("csv/" + fileName).toURI());
-    MockMultipartFile multipartFile = new MockMultipartFile("file", fileName, "csv",
-            Files.readAllBytes(csvFileLocation));
-    return multipartFile;
-  }
-
-  private MockMultipartFile getTestFileFromString(String content) throws Exception {
-    return new MockMultipartFile("file", "fileName", "csv",
-            content.getBytes());
-  }
 
   @Test
   public void testIngestBusinessSampleSuccess() throws Exception {
@@ -181,8 +130,8 @@ public class CsvIngesterBusinessTest {
     csvIngester.ingest(sampleSummary, getTestFileFromString(missingFormType));
 
     // Then
-    verify(sampleService, times(0)).processSampleSummary(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class));
+    verify(sampleService, times(0)).saveSample(eq(sampleSummary),
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -198,8 +147,8 @@ public class CsvIngesterBusinessTest {
     csvIngester.ingest(sampleSummary, getTestFileFromString(missingSampleUnitRef));
 
     // Then
-    verify(sampleService, times(0)).processSampleSummary(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class));
+    verify(sampleService, times(0)).saveSample(eq(sampleSummary),
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -19,7 +19,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterBusiness;
 import uk.gov.ons.ctp.response.sample.message.PartyPublisher;
 import uk.gov.ons.ctp.response.sample.party.PartyUtil;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
 
@@ -117,14 +117,14 @@ public class CsvIngesterBusinessTest {
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
     BusinessSampleUnit businessSampleUnit = createBusinessSampleUnit();
-    given(sampleService.saveSample(sampleSummary, Collections.singletonList(businessSampleUnit), SampleUnitDTO.SampleUnitState.INIT)).willReturn(sampleSummary);
+    given(sampleService.saveSample(sampleSummary, Collections.singletonList(businessSampleUnit), SampleUnitState.INIT)).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));
 
     // Then
     verify(sampleService, times(1)).saveSample(eq(sampleSummary),
-        anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+        anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
   }
 
   @Test
@@ -132,18 +132,18 @@ public class CsvIngesterBusinessTest {
     // Given
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
-    given(sampleService.saveSample(any(), any(), eq(SampleUnitDTO.SampleUnitState.INIT))).willReturn(sampleSummary);
+    given(sampleService.saveSample(any(), any(), eq(SampleUnitState.INIT))).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample-multiple.csv"));
 
     // Then
     verify(sampleService, times(1)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
   }
 
   @Test(expected = CTPException.class)
-  public void testParseDateFromSampleSummary() throws Exception {
+  public void testInvalidDateFromSampleSummary() throws Exception {
     // Given
     SampleSummary sampleSummary = new SampleSummary();
 
@@ -152,7 +152,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-        anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+        anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
   }
 
   @Test(expected = CTPException.class)
@@ -165,7 +165,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -214,7 +214,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -223,7 +223,7 @@ public class CsvIngesterBusinessTest {
     // Given
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
-    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitDTO.SampleUnitState.INIT))).willReturn(sampleSummary);
+    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitState.INIT))).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -15,9 +15,9 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterBusiness;
 import uk.gov.ons.ctp.response.sample.message.PartyPublisher;
 import uk.gov.ons.ctp.response.sample.party.PartyUtil;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
-import validation.SampleUnitBase;
 
 import java.util.Collections;
 import java.util.List;
@@ -113,14 +113,14 @@ public class CsvIngesterBusinessTest {
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
     BusinessSampleUnit businessSampleUnit = createBusinessSampleUnit();
-    given(sampleService.saveSample(sampleSummary, Collections.singletonList(businessSampleUnit))).willReturn(sampleSummary);
+    given(sampleService.saveSample(sampleSummary, Collections.singletonList(businessSampleUnit), SampleUnitDTO.SampleUnitState.INIT)).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));
 
     // Then
     verify(sampleService, times(1)).saveSample(eq(sampleSummary),
-        anyListOf(BusinessSampleUnit.class));
+        anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
   }
 
   @Test
@@ -128,14 +128,14 @@ public class CsvIngesterBusinessTest {
     // Given
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
-    given(sampleService.saveSample(any(), any())).willReturn(sampleSummary);
+    given(sampleService.saveSample(any(), any(), eq(SampleUnitDTO.SampleUnitState.INIT))).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample-multiple.csv"));
 
     // Then
     verify(sampleService, times(1)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
   }
 
   @Test(expected = CTPException.class)
@@ -148,7 +148,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-        anyListOf(BusinessSampleUnit.class));
+        anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
   }
 
   @Test(expected = CTPException.class)
@@ -161,7 +161,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -210,7 +210,7 @@ public class CsvIngesterBusinessTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(sampleSummary),
-            anyListOf(BusinessSampleUnit.class));
+            anyListOf(BusinessSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -219,7 +219,7 @@ public class CsvIngesterBusinessTest {
     // Given
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(UUID.randomUUID());
-    given(sampleService.saveSample(any(), argumentCaptor.capture())).willReturn(sampleSummary);
+    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitDTO.SampleUnitState.INIT))).willReturn(sampleSummary);
 
     // When
     csvIngester.ingest(sampleSummary, TestFiles.getTestFile("business-survey-sample.csv"));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -4,7 +4,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockMultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -25,8 +29,8 @@ import java.util.UUID;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
@@ -13,6 +13,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterCensus;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
 
@@ -67,7 +68,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample.csv"));
     verify(sampleService, times(1)).saveSample(eq(newSummary),
-            anyListOf(CensusSampleUnit.class));
+            anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
   }
 
   @Test(expected = Exception.class)
@@ -75,7 +76,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-missing-columns.csv"));
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(CensusSampleUnit.class));
+        anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -84,7 +85,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-incorrect-data.csv"));
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(CensusSampleUnit.class));
+        anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
@@ -1,13 +1,11 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockMultipartFile;
@@ -17,7 +15,6 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterCensus;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
-import validation.CensusSurveySample;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,7 +66,7 @@ public class CsvIngesterCensusTest {
   public void testBlueSky() throws Exception {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample.csv"));
-    verify(sampleService, times(1)).processSampleSummary(eq(newSummary),
+    verify(sampleService, times(1)).saveSample(eq(newSummary),
             anyListOf(CensusSampleUnit.class));
   }
 
@@ -77,7 +74,7 @@ public class CsvIngesterCensusTest {
   public void missingColumns() throws Exception {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-missing-columns.csv"));
-    verify(sampleService, times(0)).processSampleSummary(eq(newSummary),
+    verify(sampleService, times(0)).saveSample(eq(newSummary),
         anyListOf(CensusSampleUnit.class));
     thrown.expect(CTPException.class);
   }
@@ -86,7 +83,7 @@ public class CsvIngesterCensusTest {
   public void incorrectData() throws Exception {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-incorrect-data.csv"));
-    verify(sampleService, times(0)).processSampleSummary(eq(newSummary),
+    verify(sampleService, times(0)).saveSample(eq(newSummary),
         anyListOf(CensusSampleUnit.class));
     thrown.expect(CTPException.class);
   }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
@@ -13,7 +13,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterCensus;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
 
@@ -21,9 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -68,7 +67,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample.csv"));
     verify(sampleService, times(1)).saveSample(eq(newSummary),
-            anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+            anyListOf(CensusSampleUnit.class), eq(SampleUnitState.INIT));
   }
 
   @Test(expected = Exception.class)
@@ -76,7 +75,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-missing-columns.csv"));
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+        anyListOf(CensusSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 
@@ -85,7 +84,7 @@ public class CsvIngesterCensusTest {
     SampleSummary newSummary = new SampleSummary();
     csvIngester.ingest(newSummary, getTestFile("census-survey-sample-incorrect-data.csv"));
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(CensusSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.INIT));
+        anyListOf(CensusSampleUnit.class), eq(SampleUnitState.INIT));
     thrown.expect(CTPException.class);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -5,7 +5,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.TestFiles;
@@ -24,8 +28,8 @@ import java.util.Map;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -76,6 +76,21 @@ public class CsvIngesterSocialTest {
         anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
   }
 
+  @Test
+  public void testIngestSocialSampleFileWithByteOrderMark() throws Exception {
+    // Given
+    SampleSummary newSummary = new SampleSummary();
+    String csv = "\uFEFFPrem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
+            "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
+
+    // When
+    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
+
+    // Then
+    verify(sampleService).saveSample(eq(newSummary),
+            anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
+  }
+
   @Test(expected = CTPException.class)
   public void testMissingMandatoryColumns() throws Exception {
     // Given

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -18,7 +18,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterSocial;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
@@ -73,7 +73,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService).saveSample(eq(newSummary),
-        anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
+        anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
   }
 
   @Test(expected = CTPException.class)
@@ -88,7 +88,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
+        anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
     thrown.expect(CTPException.class);
   }
 
@@ -104,7 +104,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-            anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
+            anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
     thrown.expect(CTPException.class);
     thrown.expectMessage("Error in header row, missing required headers Prem1");
   }
@@ -113,7 +113,7 @@ public class CsvIngesterSocialTest {
   public void testIngestSocialSampleSavesAttributes() throws Exception {
     // Given
     SampleSummary newSummary = new SampleSummary();
-    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitDTO.SampleUnitState.PERSISTED))).willReturn(newSummary);
+    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitState.PERSISTED))).willReturn(newSummary);
     String csv = "Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
             "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -76,21 +76,6 @@ public class CsvIngesterSocialTest {
         anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
   }
 
-  @Test
-  public void testIngestSocialSampleFileWithByteOrderMark() throws Exception {
-    // Given
-    SampleSummary newSummary = new SampleSummary();
-    String csv = "\uFEFFPrem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
-            "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
-
-    // When
-    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
-
-    // Then
-    verify(sampleService).saveSample(eq(newSummary),
-            anyListOf(SocialSampleUnit.class), eq(SampleUnitState.PERSISTED));
-  }
-
   @Test(expected = CTPException.class)
   public void testMissingMandatoryColumns() throws Exception {
     // Given

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -14,6 +14,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterSocial;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
@@ -68,7 +69,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService).saveSample(eq(newSummary),
-        anyListOf(SocialSampleUnit.class));
+        anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
   }
 
   @Test(expected = CTPException.class)
@@ -83,7 +84,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-        anyListOf(SocialSampleUnit.class));
+        anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
     thrown.expect(CTPException.class);
   }
 
@@ -99,7 +100,7 @@ public class CsvIngesterSocialTest {
 
     // Then
     verify(sampleService, times(0)).saveSample(eq(newSummary),
-            anyListOf(SocialSampleUnit.class));
+            anyListOf(SocialSampleUnit.class), eq(SampleUnitDTO.SampleUnitState.PERSISTED));
     thrown.expect(CTPException.class);
     thrown.expectMessage("Error in header row, missing required headers Prem1");
   }
@@ -108,7 +109,7 @@ public class CsvIngesterSocialTest {
   public void testIngestSocialSampleSavesAttributes() throws Exception {
     // Given
     SampleSummary newSummary = new SampleSummary();
-    given(sampleService.saveSample(any(), argumentCaptor.capture())).willReturn(newSummary);
+    given(sampleService.saveSample(any(), argumentCaptor.capture(), eq(SampleUnitDTO.SampleUnitState.PERSISTED))).willReturn(newSummary);
     String csv = "Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
             "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterSocialTest.java
@@ -1,28 +1,27 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
-import org.junit.Before;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.mock.web.MockMultipartFile;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.response.sample.TestFiles;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.ingest.CsvIngesterSocial;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
-import validation.SocialSurveySample;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
@@ -47,39 +46,90 @@ public class CsvIngesterSocialTest {
   @Mock
   private SampleService sampleService;
 
+  @Mock
+  private SampleAttributesRepository sampleAttributesRepository;
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  /**
-   * take a named test file and create a copy of it - is because the ingester
-   * will delete the source csv file after ingest
-   *
-   * @param fileName source file name
-   * @return the newly created file
-   * @throws Exception oops
-   */
-  private MockMultipartFile getTestFile(String fileName) throws Exception {
-    Path csvFileLocation = Paths.get(getClass().getClassLoader().getResource("csv/" + fileName).toURI());
-    MockMultipartFile multipartFile = new MockMultipartFile("file", fileName, "csv",
-        Files.readAllBytes(csvFileLocation));
-    return multipartFile;
-  }
+  @Captor
+  public ArgumentCaptor<List<SocialSampleUnit>> argumentCaptor;
+
 
   @Test
-  public void testBlueSky() throws Exception {
+  public void testIngestSocialSampleFile() throws Exception {
+    // Given
     SampleSummary newSummary = new SampleSummary();
-    csvIngester.ingest(newSummary, getTestFile("social-survey-sample.csv"));
-    verify(sampleService, times(1)).processSampleSummary(eq(newSummary),
+    String csv = "Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
+            "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
+
+    // When
+    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
+
+    // Then
+    verify(sampleService).saveSample(eq(newSummary),
         anyListOf(SocialSampleUnit.class));
   }
 
   @Test(expected = CTPException.class)
-  public void missingColumns() throws Exception {
+  public void testMissingMandatoryColumns() throws Exception {
+    // Given
     SampleSummary newSummary = new SampleSummary();
-    csvIngester.ingest(newSummary, getTestFile("social-survey-sample-missing-columns.csv"));
-    verify(sampleService, times(0)).processSampleSummary(eq(newSummary),
+    String csv = "Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
+            "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,,E";
+
+    // When
+    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
+
+    // Then
+    verify(sampleService, times(0)).saveSample(eq(newSummary),
         anyListOf(SocialSampleUnit.class));
     thrown.expect(CTPException.class);
+  }
+
+  @Test(expected = CTPException.class)
+  public void testMissingMandatoryHeaders() throws Exception {
+    // Given
+    SampleSummary newSummary = new SampleSummary();
+    String csv = "Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
+            ",,,,STOCKTON-ON-TEES,TS184QG,E";
+
+    // When
+    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
+
+    // Then
+    verify(sampleService, times(0)).saveSample(eq(newSummary),
+            anyListOf(SocialSampleUnit.class));
+    thrown.expect(CTPException.class);
+    thrown.expectMessage("Error in header row, missing required headers Prem1");
+  }
+
+  @Test
+  public void testIngestSocialSampleSavesAttributes() throws Exception {
+    // Given
+    SampleSummary newSummary = new SampleSummary();
+    given(sampleService.saveSample(any(), argumentCaptor.capture())).willReturn(newSummary);
+    String csv = "Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode\n" +
+            "14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E";
+
+    // When
+    csvIngester.ingest(newSummary, TestFiles.getTestFileFromString(csv));
+
+    // Then
+    SocialSampleUnit socialSampleUnit = argumentCaptor.getValue().get(0);
+    Map<String, String> attributes = ImmutableMap.<String, String>builder()
+            .put("Prem1", "14 ASHMEAD VIEW")
+            .put("Prem2", "")
+            .put("Prem3", "")
+            .put("Prem4", "")
+            .put("District", "")
+            .put("PostTown", "STOCKTON-ON-TEES")
+            .put("Postcode", "TS184QG")
+            .put("CountryCode", "E")
+            .build();
+    SampleAttributes sampleAttriubutes = new SampleAttributes(socialSampleUnit.getSampleUnitId(), attributes);
+    List<SampleAttributes> sampleAttributesList = Collections.singletonList(sampleAttriubutes);
+    verify(sampleAttributesRepository).save(sampleAttributesList);
   }
 
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -21,6 +21,7 @@ import uk.gov.ons.ctp.response.sample.config.Rabbitmq;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO.SampleState;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 import javax.xml.bind.JAXBContext;
@@ -89,7 +90,7 @@ public class SampleEndpointIT {
         // Then
         assertThat(sampleSummaryResponse.getStatus()).isEqualTo(201);
         SampleSummary sampleSummary = mapper.readValue(sampleSummaryResponse.getBody(), new TypeReference<SampleSummary>() {});
-        assertThat(sampleSummary.getState()).isEqualTo(SampleSummaryDTO.SampleState.INIT);
+        assertThat(sampleSummary.getState()).isEqualTo(SampleState.INIT);
 
         String message = uploadFinishedMessageListener.take();
         SampleSummaryDTO active = mapper.readValue(message, SampleSummaryDTO.class);

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ons.ctp.response.sample.Unirest.initialiseUnirest;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration
@@ -65,32 +66,14 @@ public class SampleEndpointIT {
         sampleDeliveryMessageListener = sml.listen(SimpleMessageListener.ExchangeType.Direct,
                 "sample-outbound-exchange", "Sample.SampleDelivery.binding");
 
-        Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {
-            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
-                    = new com.fasterxml.jackson.databind.ObjectMapper();
-
-            public <T> T readValue(String value, Class<T> valueType) {
-                try {
-                    return jacksonObjectMapper.readValue(value, valueType);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            public String writeValue(Object value) {
-                try {
-                    return jacksonObjectMapper.writeValueAsString(value);
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+        initialiseUnirest();
     }
 
     @After
     public void tearDown() {
         sml.close();
     }
+
 
     @Test
     public void shouldUploadBusinessSampleFile() throws UnirestException, IOException, InterruptedException {

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.HttpResponse;
@@ -34,7 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ons.ctp.response.sample.Unirest.initialiseUnirest;
+import static uk.gov.ons.ctp.response.sample.UnirestInitialiser.initialiseUnirest;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -1,11 +1,14 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.apache.http.entity.ContentType;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +20,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.config.Rabbitmq;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
+import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,18 +45,53 @@ public class SampleEndpointIT {
 
     @Autowired
     private ObjectMapper mapper;
+    private SimpleMessageListener sml;
+    private BlockingQueue<String> uploadFinishedMessageListener;
+    private BlockingQueue<String> sampleDeliveryMessageListener;
+
+    @Before
+    public void setUp() throws Exception {
+        Rabbitmq config = this.appConfig.getRabbitmq();
+        sml = new SimpleMessageListener(config.getHost(), config.getPort(), config.getUsername(),
+                config.getPassword());
+
+        uploadFinishedMessageListener = sml.listen(SimpleMessageListener.ExchangeType.Direct,
+                "sample-outbound-exchange", "Sample.SampleUploadFinished.binding");
+
+        sampleDeliveryMessageListener = sml.listen(SimpleMessageListener.ExchangeType.Direct,
+                "sample-outbound-exchange", "Sample.SampleDelivery.binding");
+
+        Unirest.setObjectMapper(new com.mashape.unirest.http.ObjectMapper() {
+            private com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper
+                    = new com.fasterxml.jackson.databind.ObjectMapper();
+
+            public <T> T readValue(String value, Class<T> valueType) {
+                try {
+                    return jacksonObjectMapper.readValue(value, valueType);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            public String writeValue(Object value) {
+                try {
+                    return jacksonObjectMapper.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        sml.close();
+    }
 
     @Test
-    public void shouldUploadSampleFile() throws UnirestException, IOException, InterruptedException {
+    public void shouldUploadBusinessSampleFile() throws UnirestException, IOException, InterruptedException {
         // Given
         final String sampleFile = "/csv/business-survey-sample.csv";
-
-        Rabbitmq config = this.appConfig.getRabbitmq();
-        SimpleMessageListener sml = new SimpleMessageListener(config.getHost(), config.getPort(), config.getUsername(),
-                                                                config.getPassword());
-
-        BlockingQueue<String> msgQueue = sml.listen(SimpleMessageListener.ExchangeType.Direct,
-                "sample-outbound-exchange", "Sample.SampleUploadFinished.binding");
 
         // When
         HttpResponse<String> sampleSummaryResponse =
@@ -63,12 +105,57 @@ public class SampleEndpointIT {
         SampleSummary sampleSummary = mapper.readValue(sampleSummaryResponse.getBody(), new TypeReference<SampleSummary>() {});
         assertThat(sampleSummary.getState()).isEqualTo(SampleSummaryDTO.SampleState.INIT);
 
-        String message = msgQueue.take();
-        sml.close();
+        String message = uploadFinishedMessageListener.take();
         SampleSummaryDTO active = mapper.readValue(message, SampleSummaryDTO.class);
 
         assertThat(active.getExpectedCollectionInstruments()).isEqualTo(1);
         assertThat(active.getTotalSampleUnits()).isEqualTo(1);
     }
+
+    @Test
+    public void shouldUploadSocialSampleFile() throws UnirestException, IOException, InterruptedException {
+        // Given
+        final String sampleFile = "/csv/social-survey-sample.csv";
+
+        // When
+        HttpResponse<String> sampleSummaryResponse =
+                Unirest.post("http://localhost:" + port + "/samples/SOCIAL/fileupload")
+                        .basicAuth("admin", "secret")
+                        .field("file", getClass().getResourceAsStream(sampleFile), ContentType.MULTIPART_FORM_DATA, "file")
+                        .asString();
+
+        // Then
+        assertThat(sampleSummaryResponse.getStatus()).isEqualTo(201);
+        SampleSummary sampleSummary = mapper.readValue(sampleSummaryResponse.getBody(), new TypeReference<SampleSummary>() {});
+        assertThat(sampleSummary.getState()).isEqualTo(SampleSummaryDTO.SampleState.INIT);
+
+    }
+
+    @Test
+    public void shouldPutSampleUnitsOnQueue() throws UnirestException, InterruptedException, IOException {
+        // Given
+        final String sampleFile = "/csv/social-survey-sample.csv";
+        HttpResponse<SampleSummary> sampleSummaryResponse =
+                Unirest.post("http://localhost:" + port + "/samples/SOCIAL/fileupload")
+                        .basicAuth("admin", "secret")
+                        .field("file", getClass().getResourceAsStream(sampleFile), ContentType.MULTIPART_FORM_DATA, "file")
+                        .asObject(SampleSummary.class);
+        CollectionExerciseJobCreationRequestDTO collexJobRequest = new CollectionExerciseJobCreationRequestDTO(
+                UUID.randomUUID(), "TEST", new Date(), Collections.singletonList(sampleSummaryResponse.getBody().getId()));
+
+        // When
+        HttpResponse<String> sampleUnitResponse =
+                Unirest.post("http://localhost:" + port + "/samples/sampleunitrequests")
+                        .header("Content-Type", "application/json")
+                        .basicAuth("admin", "secret")
+                        .body(collexJobRequest)
+                        .asString();
+
+        // Then
+        assertThat(sampleUnitResponse.getStatus()).isEqualTo(201);
+        String message = sampleDeliveryMessageListener.take();
+        System.out.println(message);
+    }
+
 
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapperTest.java
@@ -26,7 +26,7 @@ public class SampleUnitMapperTest {
 
         Map<String, String> attributesMap = Collections.singletonMap("test_attribute_key", "test_attribute_value");
         SampleAttributes sampleAttributes = new SampleAttributes(sampleUnit.getId(), attributesMap);
-        sampleUnit.setSampleAttributes(Collections.singletonList(sampleAttributes));
+        sampleUnit.setSampleAttributes(sampleAttributes);
 
         uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit desinationSampleUnit = new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit();
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/mapper/SampleUnitMapperTest.java
@@ -1,0 +1,62 @@
+package uk.gov.ons.ctp.response.sample.mapper;
+
+import org.junit.Test;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleAttributes;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class SampleUnitMapperTest {
+
+    private SampleUnitMapper sampleUnitMapper = new SampleUnitMapper();
+
+    @Test
+    public void testSampleAttributeMapping() {
+        // Given
+        SampleUnit sampleUnit = new SampleUnit();
+        sampleUnit.setFormType("form_type");
+        sampleUnit.setId(UUID.randomUUID());
+        sampleUnit.setSampleUnitRef("unit_ref");
+        sampleUnit.setSampleUnitType("H");
+
+        Map<String, String> attributesMap = Collections.singletonMap("test_attribute_key", "test_attribute_value");
+        SampleAttributes sampleAttributes = new SampleAttributes(sampleUnit.getId(), attributesMap);
+        sampleUnit.setSampleAttributes(Collections.singletonList(sampleAttributes));
+
+        uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit desinationSampleUnit = new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit();
+
+        // When
+        sampleUnitMapper.mapAtoB(sampleUnit, desinationSampleUnit, null);
+
+        // Then
+        assertEquals("test_attribute_key", desinationSampleUnit.getSampleAttributes().getEntries().get(0).getKey());
+        assertEquals("test_attribute_value", desinationSampleUnit.getSampleAttributes().getEntries().get(0).getValue());
+        assertEquals(sampleUnit.getFormType(), desinationSampleUnit.getFormType());
+        assertEquals(sampleUnit.getSampleUnitType(), desinationSampleUnit.getSampleUnitType());
+        assertEquals(sampleUnit.getSampleUnitRef(), desinationSampleUnit.getSampleUnitRef());
+    }
+
+    @Test
+    public void testMappingNullSampleAttributes() {
+        // Given
+        SampleUnit sampleUnit = new SampleUnit();
+        uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit desinationSampleUnit = new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit();
+
+        // When
+        sampleUnitMapper.mapAtoB(sampleUnit, desinationSampleUnit, null);
+
+        // Then
+        assertNull(desinationSampleUnit.getSampleAttributes());
+        assertNull(desinationSampleUnit.getSampleAttributes());
+        assertNull(desinationSampleUnit.getSampleAttributes());
+        assertNull(desinationSampleUnit.getFormType());
+        assertNull(desinationSampleUnit.getSampleUnitType());
+        assertNull(desinationSampleUnit.getSampleUnitRef());
+    }
+
+}

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -27,7 +27,6 @@ import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +35,9 @@ import java.util.UUID;
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test the Sample Unit Distributor

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -25,7 +25,8 @@ import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesReposito
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitEvent;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -73,7 +74,7 @@ public class SampleUnitDistributorTest {
   private MapperFacade mapperFacade = new SampleBeanMapper();
 
   @Mock
-  private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent> sampleUnitStateTransitionManager;
+  private StateTransitionManager<SampleUnitState, SampleUnitEvent> sampleUnitStateTransitionManager;
 
   @InjectMocks
   private SampleUnitDistributor sampleUnitDistributor;
@@ -112,7 +113,7 @@ public class SampleUnitDistributorTest {
     verify(sampleUnitDistributionListManager, times(1)).saveList(any(String.class),
             any(List.class), any(Boolean.class));
     verify(sampleUnitStateTransitionManager, times(2)).transition(
-            SampleUnitDTO.SampleUnitState.INIT, SampleUnitDTO.SampleUnitEvent.DELIVERING);
+            SampleUnitState.INIT, SampleUnitEvent.DELIVERING);
     verify(sampleUnitRepo, times(2)).saveAndFlush(any(SampleUnit.class));
 
     verify(sampleUnitPublisher, times(2)).send(
@@ -232,7 +233,7 @@ public class SampleUnitDistributorTest {
     verify(sampleUnitDistributionListManager, times(1)).saveList(any(String.class),
             any(List.class), any(Boolean.class));
     verify(sampleUnitStateTransitionManager, times(2)).transition(
-            SampleUnitDTO.SampleUnitState.INIT, SampleUnitDTO.SampleUnitEvent.DELIVERING);
+            SampleUnitState.INIT, SampleUnitEvent.DELIVERING);
     verify(sampleUnitRepo, times(2)).saveAndFlush(any(SampleUnit.class));
 
     verify(sampleUnitPublisher, times(2)).send(

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SendToCollExQueueTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SendToCollExQueueTest.java
@@ -1,18 +1,6 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
+import ma.glasnost.orika.MapperFacade;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,8 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import ma.glasnost.orika.MapperFacade;
 import uk.gov.ons.ctp.common.distributed.DistributedListManager;
 import uk.gov.ons.ctp.common.state.StateTransitionManager;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
@@ -32,8 +18,20 @@ import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRep
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
-import uk.gov.ons.ctp.response.sample.scheduled.distribution.SampleUnitDistributor;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by wardlk on 02/05/2017.
@@ -77,7 +75,7 @@ public class SendToCollExQueueTest {
     public void verifyRetrievedSampleUnitsAreDeliveredToTheQueue() throws Exception{
         UUID cEId = UUID.randomUUID();
         when(collectionExerciseJobRepository.findAll()).thenReturn(Collections.singletonList(new CollectionExerciseJob(1,cEId,"str1234",new Timestamp(0),new Timestamp(0),UUID.randomUUID())));
-        SampleUnit su1 = SampleUnit.builder().sampleSummaryFK(1).sampleUnitPK(2).sampleUnitRef("str1234").sampleUnitType("H").state(SampleUnitDTO.SampleUnitState.INIT).build();
+        SampleUnit su1 = SampleUnit.builder().sampleSummaryFK(1).sampleUnitPK(2).sampleUnitRef("str1234").sampleUnitType("H").state(SampleUnitState.INIT).build();
         SampleUnit su2 = SampleUnit.builder().sampleUnitPK(3).build();
         List<SampleUnit> suList = new ArrayList<>();
         suList.add(su1);
@@ -89,7 +87,7 @@ public class SendToCollExQueueTest {
         sud.setRetrievalMax(2);
         when(appConfig.getSampleUnitDistribution()).thenReturn(sud);
         when(mapperFacade.map(any(),any())).thenReturn(new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit());
-        when(sampleUnitStateTransitionManager.transition(any(),any())).thenReturn(SampleUnitDTO.SampleUnitState.DELIVERED);
+        when(sampleUnitStateTransitionManager.transition(any(),any())).thenReturn(SampleUnitState.DELIVERED);
 
         when(sampleUnitDistributionListManager.findList(anyString(), anyBoolean())).thenReturn(new ArrayList<Integer>());
         

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SendToCollExQueueTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SendToCollExQueueTest.java
@@ -29,6 +29,7 @@ import uk.gov.ons.ctp.response.sample.config.SampleUnitDistribution;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRepository;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleAttributesRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
@@ -63,7 +64,9 @@ public class SendToCollExQueueTest {
     
     @Mock
     private DistributedListManager<Integer> sampleUnitDistributionListManager;
-    
+
+    @Mock
+    private SampleAttributesRepository sampleAttributesRepository;
     
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.sample.service.impl;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,9 +32,7 @@ import uk.gov.ons.ctp.response.sample.service.PartySvcClientService;
 import validation.BusinessSurveySample;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Future;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -140,7 +137,7 @@ public class SampleServiceImplTest {
     SampleSummary newSummary = sampleServiceImpl.createAndSaveSampleSummary();
     BusinessSurveySample businessSample = surveySample.get(0);
 
-    sampleServiceImpl.processSampleSummary(newSummary, businessSample.getSampleUnits());
+    sampleServiceImpl.saveSample(newSummary, businessSample.getSampleUnits());
 
     verify(sampleSummaryRepository, times(2)).save(any(SampleSummary.class));
     verify(sampleUnitRepository, times(2)).save(any(SampleUnit.class));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImplTest.java
@@ -133,15 +133,14 @@ public class SampleServiceImplTest {
    * @throws Exception oops
    */
   @Test
-  public void testSampleSummaryAndSampleUnitsAreSavedAndThenSampleUnitsPublishedToQueue() {
+  public void testSampleSummaryAndSampleUnitsAreSaved() {
     SampleSummary newSummary = sampleServiceImpl.createAndSaveSampleSummary();
     BusinessSurveySample businessSample = surveySample.get(0);
 
-    sampleServiceImpl.saveSample(newSummary, businessSample.getSampleUnits());
+    sampleServiceImpl.saveSample(newSummary, businessSample.getSampleUnits(), SampleUnitState.INIT);
 
     verify(sampleSummaryRepository, times(2)).save(any(SampleSummary.class));
     verify(sampleUnitRepository, times(2)).save(any(SampleUnit.class));
-    verify(partyPublisher, times(2)).publish(any(PartyCreationRequestDTO.class));
   }
 
   /**

--- a/src/test/resources/csv/social-survey-sample-missing-columns.csv
+++ b/src/test/resources/csv/social-survey-sample-missing-columns.csv
@@ -1,2 +1,0 @@
-Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode
-14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,,E

--- a/src/test/resources/csv/social-survey-sample-missing-columns.csv
+++ b/src/test/resources/csv/social-survey-sample-missing-columns.csv
@@ -1,1 +1,2 @@
-CuFT
+Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode
+14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,,E

--- a/src/test/resources/csv/social-survey-sample.csv
+++ b/src/test/resources/csv/social-survey-sample.csv
@@ -1,2 +1,2 @@
-Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode
+﻿Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode
 14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E

--- a/src/test/resources/csv/social-survey-sample.csv
+++ b/src/test/resources/csv/social-survey-sample.csv
@@ -1,1 +1,2 @@
-SSD0001:CuFT
+Prem1,Prem2,Prem3,Prem4,District,PostTown,Postcode,CountryCode
+14 ASHMEAD VIEW,,,,,STOCKTON-ON-TEES,TS184QG,E


### PR DESCRIPTION
Social files currently have four required attribute fields and can contain an arbitrary number of non mandatory attributes. The attributes are described by a header row in the sample file.

Adds functionality to parse a social sample file, persist sample attributes and post attributes to collection exercise. When a file is uploaded it is parsed and validated. If valid, it will be saved to a sample attributes table in the sample database linked by the sample unit id (UUID). When a request is made for samples the sample unit and sample attributes and put on the sample delivery queue.

We have added integration tests to exercise the upload functionality and ensure they are published to the queue with the sample attributes. 

**How to test:**
Requires changes in these branches:
https://github.com/ONSdigital/rm-samplesvc-api/pull/11
https://github.com/ONSdigital/rm-party-service-api/pull/11

You'll have to build them locally then point the pom file to those snapshots, this will block Travis from building until those changes are on master.

Try loading a social sample through the endpoint using the loader script:
https://github.com/ONSdigital/rm-sample-service/pull/45

You should also try the loader script with a full example sample file, there is one available as an attachment on the story card:
![](https://github.trello.services/images/mini-trello-icon.png) [Dev task 1: INT: load a social sample file (13)](https://trello.com/c/lTUmPnuf/97-dev-task-1-int-load-a-social-sample-file-13)

Also requires these changes before being merged:
https://github.com/ONSdigital/rm-samplesvc-api/pull/9
https://github.com/ONSdigital/rm-sample-service/pull/42
