### PR TITLE
Remove SFTP container from compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,6 @@ services:
     - "6672:5672"
     - "16671:15671"
     - "16672:15672"
- sftp:
-    container_name: sftp
-    image: atmoz/sftp
-    volumes:
-        - ~/Documents/sftp:/home/centos/Documents/sftp
-    ports:
-        - "122:22"
-    command: centos:JLibV2&XD,:1001
  party-service:
   container_name: party-service
   image: sdcplatform/ras-party


### PR DESCRIPTION
# Motivation and Context
The SFTP being in the compose file wrongly indicates that the
rm-collection-exercise-service needs an SFTP server to run. There is no
dependencies on an SFTP server so removing.

# What has changed
Remove SFTP container from compose file

# How to test?
Integration tests pass in travis (See https://github.com/ONSdigital/rm-sample-service/pull/54)