### PR TITLE
Run integration tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ jdk: openjdk8
 
 before_install: cp .maven.settings.xml $HOME/.m2/settings.xml
 
-script:
-  - mvn clean verify
-  - "mvn cobertura:cobertura"
+install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmaven.javadoc.skip=true -B -V
+script: mvn fmt:check cobertura:cobertura-integration-test
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then


### PR DESCRIPTION
# Motivation and Context
Travis will run `mvn install -DskipTests=true -Dmaven.javadoc.skip=true
-B -V` on the install step by default which runs the integration tests
and builds the docker containers which makes the build take twice as
long. Changing it to skip docker and integration tests

# What has changed
* Skip docker and IT on install
* Run integration tests in travis

# How to test?
Travis is green
Check integration tests aren't ran in `install` step on travis