### PR TITLE
Tidied up Maven pom.xml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,29 +4,29 @@ services:
   container_name: postgres
   image: sdcplatform/ras-rm-docker-postgres
   ports:
-   - "6432:5432"
+   - "36432:5432"
  redis:
   container_name: redis
   image: redis:3.2.9
   ports:
-   - "7379:6379"
+   - "37379:6379"
  rabbitmq:
   container_name: rabbitmq
   image: rabbitmq:3.6.10-management
   ports:
-    - "5369:4369"
-    - "45672:25672"
-    - "6671:5671"
-    - "6672:5672"
-    - "16671:15671"
-    - "16672:15672"
+    - "35369:4369"
+    - "55672:25672"
+    - "36671:5671"
+    - "36672:5672"
+    - "26671:15671"
+    - "26672:15672"
  party-service:
   container_name: party-service
   image: sdcplatform/ras-party
   links:
         - "postgres:postgres"
   ports:
-    - "8081:8081"
+    - "38081:8081"
   environment:
     - DATABASE_URI=postgresql://postgres:postgres@postgres:5432/postgres
     - SECURITY_USER_NAME=admin

--- a/pom.xml
+++ b/pom.xml
@@ -1,379 +1,418 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
-  <artifactId>samplesvc</artifactId>
-  <version>10.49.15-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>samplesvc</artifactId>
+    <version>10.49.15-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>CTP : SampleService</name>
-  <description>CTP : SampleService</description>
+    <name>CTP : SampleService</name>
+    <description>CTP : SampleService</description>
 
-  <parent>
-    <groupId>uk.gov.ons.ctp.product</groupId>
-    <artifactId>rm-common-config</artifactId>
-    <version>10.49.12</version>
-  </parent>
+    <parent>
+        <groupId>uk.gov.ons.ctp.product</groupId>
+        <artifactId>rm-common-config</artifactId>
+        <version>10.49.12</version>
+    </parent>
 
-  <scm>
-    <connection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</connection>
-    <developerConnection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</developerConnection>
-    <url>https://github.com/ONSdigital/rm-sample-service.git</url>
-    <tag>HEAD</tag>
-  </scm>
+    <scm>
+        <connection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</connection>
+        <developerConnection>scm:git:https://github.com/ONSdigital/rm-sample-service.git
+        </developerConnection>
+        <url>https://github.com/ONSdigital/rm-sample-service.git</url>
+        <tag>HEAD</tag>
+    </scm>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>uk.gov.ons.ctp.product</groupId>
-      <artifactId>partysvc-api</artifactId>
-      <version>10.50.7</version>
-    </dependency>
+    <profiles>
+        <profile>
+            <id>artifactory</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.product</groupId>
-      <artifactId>samplesvc-api</artifactId>
-      <version>10.49.16</version>
-    </dependency>
+            <repositories>
+                <repository>
+                    <id>release-repo</id>
+                    <name>libs-release</name>
+                    <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-release-local</url>
+                </repository>
+                <repository>
+                    <id>snapshot-repo</id>
+                    <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-snapshot-local/</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.product</groupId>
-      <artifactId>reportmodule</artifactId>
-      <version>10.49.0</version>
-    </dependency>
+    <dependencies>
+        <!-- Spring dependencies -->
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.common</groupId>
-      <artifactId>framework</artifactId>
-      <version>10.49.12</version>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>net.logstash.logback</groupId>
-      <artifactId>logstash-logback-encoder</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>ma.glasnost.orika</groupId>
-      <artifactId>orika-eclipse-tools</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jetty</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-spring-service-connector</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-redis</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-integration</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-sftp</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-spring-service-connector</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-xml</artifactId>
+        </dependency>
 
-    <!-- If you intend to deploy the app on Cloud Foundry, add the following -->
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-redis</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-integration</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-amqp</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-sftp</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-xml</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-redis</artifactId>
-    </dependency>
+        <!-- If you intend to deploy the app on Cloud Foundry, add the following -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-amqp</artifactId>
-    </dependency>
+        <!-- SPRING END -->
 
-    <dependency>
-      <groupId>org.springframework.amqp</groupId>
-      <artifactId>spring-rabbit</artifactId>
-    </dependency>
+        <!-- ONS libraries-->
 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>uk.gov.ons.ctp.product</groupId>
+            <artifactId>partysvc-api</artifactId>
+            <version>10.50.7</version>
+        </dependency>
 
-    <dependency>
-      <groupId>redis.clients</groupId>
-      <artifactId>jedis</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>uk.gov.ons.ctp.product</groupId>
+            <artifactId>samplesvc-api</artifactId>
+            <version>10.49.16</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>uk.gov.ons.ctp.product</groupId>
+            <artifactId>reportmodule</artifactId>
+            <version>10.49.0</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jdbc</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>uk.gov.ons.ctp.common</groupId>
+            <artifactId>framework</artifactId>
+            <version>10.49.12</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.liquibase</groupId>
-      <artifactId>liquibase-core</artifactId>
-    </dependency>
+        <!-- ONS END -->
 
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-    </dependency>
+        <!-- Third party libraries -->
 
-    <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>net.sourceforge.cobertura</groupId>
-      <artifactId>cobertura</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>servlet-api-2.5</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <dependency>
+            <groupId>ma.glasnost.orika</groupId>
+            <artifactId>orika-eclipse-tools</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.common</groupId>
-      <artifactId>test-framework</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-solr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.mashape.unirest</groupId>
-      <artifactId>unirest-java</artifactId>
-      <version>1.4.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-csv</artifactId>
-      <version>1.5</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vladmihalcea</groupId>
-      <artifactId>hibernate-types-5</artifactId>
-      <version>2.2.1</version>
-    </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
 
-  <build>
-    <defaultGoal>clean install</defaultGoal>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.18.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <phase>integration-test</phase>
-            <configuration>
-              <!-- rerun tests because schema isn't create successfully first time -->
-              <rerunFailingTestsCount>2</rerunFailingTestsCount>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <executable>true</executable>
-          <mainClass>uk.gov.ons.ctp.response.sample.SampleSvcApplication</mainClass>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>dockerfile-maven-plugin</artifactId>
-        <version>1.3.4</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <repository>sdcplatform/${project.artifactId}</repository>
-              <buildArgs>
-                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-              </buildArgs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>0.23.0</version>
-        <executions>
-          <execution>
-            <id>pre-stop</id>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}</basedir>
-                  </external>
-                </image>
-              </images>
-            </configuration>
-          </execution>
-          <execution>
-            <id>start</id>
-            <goals>
-              <goal>start</goal>
-            </goals>
-            <configuration>
-              <showLogs>false</showLogs>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}</basedir>
-                  </external>
-                </image>
-              </images>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop</id>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}</basedir>
-                  </external>
-                </image>
-              </images>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-          <check />
-        </configuration>
-      </plugin>
-    </plugins>
+        <dependency>
+            <groupId>net.sourceforge.cobertura</groupId>
+            <artifactId>cobertura</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vladmihalcea</groupId>
+            <artifactId>hibernate-types-5</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+
+        <!-- Third party end -->
+
+        <!-- Testing -->
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.ons.ctp.common</groupId>
+            <artifactId>test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mashape.unirest</groupId>
+            <artifactId>unirest-java</artifactId>
+            <version>1.4.9</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <defaultGoal>clean install</defaultGoal>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <!-- rerun tests because schema isn't create successfully first time -->
+                            <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <executable>true</executable>
+                    <mainClass>uk.gov.ons.ctp.response.sample.SampleSvcApplication</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>1.3.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <repository>sdcplatform/${project.artifactId}</repository>
+                            <buildArgs>
+                                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                            </buildArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.23.0</version>
+                <executions>
+                    <execution>
+                        <id>pre-stop</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>start</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <showLogs>false</showLogs>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <external>
+                                        <type>compose</type>
+                                        <basedir>${project.basedir}</basedir>
+                                    </external>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>xml</format>
+                    </formats>
+                    <check/>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 
 </project>
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,12 +1,27 @@
 liquibase:
   user: postgres
   password: postgres
+  url: jdbc:postgresql://localhost:36432/postgres
 
 spring:
   datasource:
     schema: classpath:/schema.sql
     username: postgres
     password: postgres
+    url: jdbc:postgresql://localhost:36432/postgres
 
 sample-unit-distribution:
   delay-milli-seconds: 1000
+
+party-svc:
+  connection-config:
+    port: 38081
+
+rabbitmq:
+  port: 36672
+
+redis:
+  port: 37379
+
+data-grid:
+  address: localhost:37379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ liquibase:
   user: samplesvc
   password: samplesvc
   default-schema: sample
-  url: jdbc:postgresql://localhost:6432/postgres
+  url: jdbc:postgresql://localhost:36432/postgres
   changeLog: classpath:/database/changelog-master.yml
 
 security:
@@ -53,7 +53,7 @@ spring:
   application:
     name: ONS SampleService
   datasource:
-    url: jdbc:postgresql://localhost:6432/postgres
+    url: jdbc:postgresql://localhost:36432/postgres
     username: samplesvc
     password: samplesvc
     driverClassName: org.postgresql.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,10 +111,10 @@ rabbitmq:
 
 redis:
   host: localhost
-  port: 7379
+  port: 37379
 
 data-grid:
-  address: localhost:7379
+  address: localhost:37379
   list-time-to-live-seconds: 600
   list-time-to-wait-seconds: 600
   lock-time-to-live-seconds: 600

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,7 +83,7 @@ party-svc:
   connection-config:
     scheme: http
     host: localhost
-    port: 8081
+    port: 38081
     username: admin
     password: secret
 
@@ -105,7 +105,7 @@ rabbitmq:
   username: guest
   password: guest
   host: localhost
-  port: 6672
+  port: 36672
   virtualhost: /
   cron: "* * * * * ?"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ liquibase:
   user: samplesvc
   password: samplesvc
   default-schema: sample
-  url: jdbc:postgresql://localhost:36432/postgres
+  url: jdbc:postgresql://localhost:6432/postgres
   changeLog: classpath:/database/changelog-master.yml
 
 security:
@@ -53,7 +53,7 @@ spring:
   application:
     name: ONS SampleService
   datasource:
-    url: jdbc:postgresql://localhost:36432/postgres
+    url: jdbc:postgresql://localhost:6432/postgres
     username: samplesvc
     password: samplesvc
     driverClassName: org.postgresql.Driver
@@ -83,7 +83,7 @@ party-svc:
   connection-config:
     scheme: http
     host: localhost
-    port: 38081
+    port: 8081
     username: admin
     password: secret
 
@@ -105,16 +105,16 @@ rabbitmq:
   username: guest
   password: guest
   host: localhost
-  port: 36672
+  port: 6672
   virtualhost: /
   cron: "* * * * * ?"
 
 redis:
   host: localhost
-  port: 37379
+  port: 7379
 
 data-grid:
-  address: localhost:37379
+  address: localhost:7379
   list-time-to-live-seconds: 600
   list-time-to-wait-seconds: 600
   lock-time-to-live-seconds: 600


### PR DESCRIPTION
### Motivation and Context
The Maven dependencies were not organised very logically. There were a couple of dependencies which could be removed. Also, the artifactory repos were missing, which meant that developers had to update their local settings.xml to be able to build the project.

### What has Changed?

1. Added section with "artifactory" profile, after the section
2. Added "spring-boot-starter-web" as first dependency, with tomcat exclusion
3. Removed "spring-boot-starter-jdbc" dependency
4. Removed "javax.servlet-api" dependency
5. Removed "spring-boot-starter-data-solr" dependency
6. Grouped all the spring dependencies together with a comment at the top and the bottom
7. Grouped the ONS dependencies together with a comment at the top and the bottom
8. Grouped the 3rd party dependencies together with a comment at the top and the bottom
9. Grouped the testing libraries together with a comment at the top and the bottom

### How to Test?
Checked file size of the JAR file before & after changes. 
Ran the acceptance tests - passing.

### Links
Trello: https://trello.com/c/pTzD9hbN/249-refactor-java-service-and-align-the-maven-configuration-removing-redundant-dependenciesm