### PR TITLE
Run mvn install while ras-rm-docker-dev is running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,23 @@
 version: '2'
 services:
- postgres:
-  container_name: postgres
-  image: sdcplatform/ras-rm-docker-postgres
-  ports:
-   - "36432:5432"
- redis:
-  container_name: redis
-  image: redis:3.2.9
-  ports:
-   - "37379:6379"
- rabbitmq:
-  container_name: rabbitmq
-  image: rabbitmq:3.6.10-management
-  ports:
-    - "35369:4369"
-    - "55672:25672"
-    - "36671:5671"
-    - "36672:5672"
-    - "26671:15671"
-    - "26672:15672"
- party-service:
-  container_name: party-service
-  image: sdcplatform/ras-party
-  links:
-        - "postgres:postgres"
-  ports:
-    - "38081:8081"
-  environment:
-    - DATABASE_URI=postgresql://postgres:postgres@postgres:5432/postgres
+  postgres:
+    container_name: postgres-sample-it
+    image: sdcplatform/ras-rm-docker-postgres
+    ports:
+    - 36432:5432
+  redis:
+    image: redis:3.2.9
+    ports:
+    - 37379:6379
+  rabbitmq:
+    image: rabbitmq:3.6.10-management
+    ports:
+    - 36672:5672
+  party-service:
+    image: sdcplatform/ras-party
+    ports:
+      - 38081:8081
+    environment:
+    - DATABASE_URI=postgresql://postgres:postgres@postgres-sample-it:5432/postgres
     - SECURITY_USER_NAME=admin
     - SECURITY_USER_PASSWORD=secret

--- a/pom.xml
+++ b/pom.xml
@@ -317,78 +317,36 @@
                 <artifactId>fmt-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.3.4</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
-                            <buildArgs>
-                                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
-                            </buildArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>0.23.0</version>
+                <groupId>com.dkanejs.maven.plugins</groupId>
+                <artifactId>docker-compose-maven-plugin</artifactId>
+                <version>2.0.1</version>
+                <configuration>
+                    <composeFile>${project.basedir}/docker-compose.yml</composeFile>
+                </configuration>
                 <executions>
                     <execution>
                         <id>pre-stop</id>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
                         <phase>pre-integration-test</phase>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
-                        </configuration>
+                        <goals>
+                            <goal>down</goal>
+                        </goals>
                     </execution>
                     <execution>
                         <id>start</id>
+                        <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>start</goal>
+                            <goal>up</goal>
                         </goals>
                         <configuration>
-                            <showLogs>false</showLogs>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
+                            <detachedMode>true</detachedMode>
                         </configuration>
                     </execution>
                     <execution>
                         <id>stop</id>
+                        <phase>post-integration-test</phase>
                         <goals>
-                            <goal>stop</goal>
+                            <goal>down</goal>
                         </goals>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <external>
-                                        <type>compose</type>
-                                        <basedir>${project.basedir}</basedir>
-                                    </external>
-                                </image>
-                            </images>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
# Motivation and Context
There were docker container name clashes when running `mvn install` when
the ras-rm-docker-dev containers we running. This change renames the
container names so they don't clash.

# What has changed
* Most containers use generated container names
* Postgres uses a fixed container name with sample-it namespace
* Removed exposed ports that aren't used
* Changed docker maven plugin as fabric8io/docker-maven-plugin was
  transposing the dockerfile and not using it like `docker-compose up`
  would. This lead to differences like the hostnames not being used.

# How to test?
1. Run `make up` in ras-rm-docker-dev
2. Wait for containers to spin up fully
3. Run `mvn install`
