### PR TITLE
Correct the app version in the pom to 10.49.15-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>samplesvc</artifactId>
-	<version>10.49.14</version>
+	<version>10.49.15-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>CTP : SampleService</name>
 	<description>CTP : SampleService</description>
@@ -14,7 +14,7 @@
 		<connection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</connection>
 		<developerConnection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</developerConnection>
 		<url>https://github.com/ONSdigital/rm-sample-service.git</url>
-		<tag>samplesvc-10.49.14</tag>
+		<tag>HEAD</tag>
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Motivation and Context
correcting the service version back to 10.49.15-SNAPSHOT as this was changed by mistake in this PR: https://github.com/ONSdigital/rm-sample-service/pull/62, this is currently stopping the mvn release tool from tagging the next release

# What has changed
Version in the pom has been corrected to be 10.49.15-SNAPSHOT

