### PR TITLE
Roll out Godaddy logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>uk.gov.ons.ctp.product</groupId>
 		<artifactId>rm-common-config</artifactId>
-		<version>10.49.12</version>
+		<version>10.49.13</version>
 	</parent>
 	<scm>
 		<connection>scm:git:https://github.com/ONSdigital/rm-sample-service.git</connection>
@@ -172,6 +172,10 @@
 			<groupId>uk.gov.ons.tools</groupId>
 			<artifactId>rabbit</artifactId>
 			<version>1.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.godaddy</groupId>
+			<artifactId>logging</artifactId>
 		</dependency>
 		<!-- END -->
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.sample;
 
+import com.godaddy.logging.LoggingConfigs;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -52,6 +53,8 @@ public class SampleSvcApplication {
    * @param args These are the optional command line arguments
    */
   public static void main(final String[] args) {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
+
     SpringApplication.run(SampleSvcApplication.class, args);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -10,7 +12,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.validation.Valid;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -42,8 +43,8 @@ import validation.BusinessSampleUnit;
 /** The REST endpoint controller for Sample Service. */
 @RestController
 @RequestMapping(value = "/samples", produces = "application/json")
-@Slf4j
 public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
+  private static final Logger log = LoggerFactory.getLogger(SampleEndpoint.class);
 
   private static final int NUM_UPLOAD_THREADS = 5;
   private static final ExecutorService EXECUTOR_SERVICE =

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,7 +17,6 @@ import liquibase.util.StringUtils;
 import liquibase.util.csv.opencsv.CSVReader;
 import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -30,9 +31,9 @@ import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
 import validation.SampleUnitBase;
 
-@Slf4j
 @Service
 public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
+  private static final Logger log = LoggerFactory.getLogger(CsvIngesterBusiness.class);
 
   private static final String SAMPLEUNITREF = "sampleUnitRef";
   private static final String FORMTYPE = "formType";

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,7 +16,6 @@ import javax.validation.ValidatorFactory;
 import liquibase.util.csv.opencsv.CSVReader;
 import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -25,9 +26,9 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitSta
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.CensusSampleUnit;
 
-@Slf4j
 @Service
 public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
+  private static final Logger log = LoggerFactory.getLogger(CsvIngesterCensus.class);
 
   private static final String SAMPLEUNITREF = "sampleUnitRef";
   private static final String FORMTYPE = "formType";

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.google.common.collect.Sets;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -7,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -26,9 +27,9 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitSta
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.SocialSampleUnit;
 
-@Slf4j
 @Service
 public class CsvIngesterSocial extends CsvToBean<SocialSampleUnit> {
+  private static final Logger log = LoggerFactory.getLogger(CsvIngesterSocial.class);
 
   @Autowired private SampleService sampleService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/EventPublisher.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.annotation.MessageEndpoint;
 
 @MessageEndpoint
-@Slf4j
 public class EventPublisher {
+  private static final Logger log = LoggerFactory.getLogger(EventPublisher.class);
 
   @Qualifier("amqpTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyPublisher.java
@@ -1,15 +1,16 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.annotation.MessageEndpoint;
 import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 
-@Slf4j
 @MessageEndpoint
 public class PartyPublisher {
+  private static final Logger log = LoggerFactory.getLogger(PartyPublisher.class);
 
   @Qualifier("partyRabbitTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyReceiver.java
@@ -1,15 +1,16 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import uk.gov.ons.ctp.response.party.definition.PartyCreationRequestDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 
-@Slf4j
 @MessageEndpoint
 public class PartyReceiver {
+  private static final Logger log = LoggerFactory.getLogger(PartyReceiver.class);
 
   @Autowired private SampleService sampleService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleOutboundPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleOutboundPublisher.java
@@ -2,7 +2,8 @@ package uk.gov.ons.ctp.response.sample.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -11,9 +12,9 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 
 /** Publisher of messages about samples uploaded */
-@Slf4j
 @MessageEndpoint
 public class SampleOutboundPublisher {
+  private static final Logger log = LoggerFactory.getLogger(SampleOutboundPublisher.class);
 
   private static final String UPLOAD_STARTED_ROUTING_KEY = "Sample.SampleUploadStarted.binding";
   private static final String UPLOAD_FINISHED_ROUTING_KEY = "Sample.SampleUploadFinished.binding";

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleUnitPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleUnitPublisher.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,9 +11,9 @@ import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /** The publisher to queues */
 @CoverageIgnore
-@Slf4j
 @MessageEndpoint
 public class SampleUnitPublisher {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitPublisher.class);
 
   @Qualifier("sampleUnitRabbitTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,8 +27,9 @@ import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /** Distributes SampleUnits to Collex when requested via job. Retries failures until successful */
 @Component
-@Slf4j
 public class SampleUnitDistributor {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitDistributor.class);
+
   private static final String LOCK_PREFIX = "SampleCollexJob-";
 
   @Autowired private AppConfig appConfig;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSender.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSender.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -16,9 +17,10 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitSta
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
 
 /** Sends SampleUnits via Rabbit queue and updates DB state */
-@Slf4j
 @Component
 public class SampleUnitSender {
+  private static final Logger log = LoggerFactory.getLogger(SampleUnitSender.class);
+
   private final SampleUnitRepository sampleUnitRepository;
 
   private final SampleUnitPublisher sampleUnitPublisher;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/CollectionExerciseJobService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/CollectionExerciseJobService.java
@@ -1,7 +1,8 @@
 package uk.gov.ons.ctp.response.sample.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -11,8 +12,8 @@ import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRep
 
 /** Accept feedback from handlers */
 @Service
-@Slf4j
 public class CollectionExerciseJobService {
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseJobService.class);
 
   @Autowired private CollectionExerciseJobRepository collectionExerciseJobRepository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/PartySvcClientService.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.sample.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -20,9 +21,9 @@ import uk.gov.ons.ctp.response.party.representation.PartyDTO;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.message.EventPublisher;
 
-@Slf4j
 @Service
 public class PartySvcClientService {
+  private static final Logger log = LoggerFactory.getLogger(PartySvcClientService.class);
 
   @Autowired private AppConfig appConfig;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleReportService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleReportService.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleReportRepository;
@@ -10,8 +11,8 @@ import uk.gov.ons.ctp.response.sample.domain.repository.SampleReportRepository;
  * SampleReport entity model.
  */
 @Service
-@Slf4j
 public class SampleReportService {
+  private static final Logger log = LoggerFactory.getLogger(SampleReportService.class);
 
   @Autowired private SampleReportRepository sampleReportRepository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.sample.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
@@ -37,10 +38,10 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitEve
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import validation.SampleUnitBase;
 
-@Slf4j
 @Service
 @Configuration
 public class SampleService {
+  private static final Logger log = LoggerFactory.getLogger(SampleService.class);
 
   @Autowired private SampleSummaryRepository sampleSummaryRepository;
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,31 +9,49 @@
     value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
   <property name="SYSLOG_PATTERN"
     value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+  <property name="ISO8601_DATE_FORMAT" value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
 
   <appender name="CLOUD" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
-        <mdc/>
-        <pattern>
-          <pattern>
-            {
-            "created": "%date{ISO8601}",
-            "service": "samplesvc",
-            "level": "%level",
-            "event": "%message"
-            }
-          </pattern>
-        </pattern>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+          <pattern>${ISO8601_DATE_FORMAT}</pattern>
+          <fieldName>created</fieldName>
+        </timestamp>
+        <globalCustomFields>
+          <customFields>{"service":"samplesvc"}</customFields>
+        </globalCustomFields>
+        <message>
+          <fieldName>event</fieldName>
+        </message>
+        <loggerName/>
+        <threadName/>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
         <stackTrace>
           <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-            <maxDepthPerThrowable>30</maxDepthPerThrowable>
-            <maxLength>2048</maxLength>
-            <shortenedClassNameLength>20</shortenedClassNameLength>
+            <maxDepthPerThrowable>20</maxDepthPerThrowable>
+            <maxLength>1000</maxLength>
+            <shortenedClassNameLength>30</shortenedClassNameLength>
+            <rootCauseFirst>true</rootCauseFirst>
             <exclude>^sun\.reflect\..*\.invoke</exclude>
             <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
-            <rootCauseFirst>true</rootCauseFirst>
           </throwableConverter>
         </stackTrace>
+        <context/>
+        <jsonMessage/>
+        <mdc>
+          <includeMdcKeyName>included</includeMdcKeyName>
+        </mdc>
+        <contextMap/>
+        <tags/>
+        <logstashMarkers/>
+        <arguments>
+          <includeNonStructuredArguments>true</includeNonStructuredArguments>
+          <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
+        </arguments>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -5,6 +5,8 @@ import static org.assertj.core.data.MapEntry.entry;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
@@ -15,7 +17,6 @@ import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.http.entity.ContentType;
 import org.junit.After;
 import org.junit.Before;
@@ -43,8 +44,8 @@ import uk.gov.ons.tools.rabbit.SimpleMessageListener;
 @ContextConfiguration
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@Slf4j
 public class SampleEndpointIT {
+  private static final Logger log = LoggerFactory.getLogger(SampleEndpointIT.class);
 
   @Autowired private AppConfig appConfig;
 


### PR DESCRIPTION
# Motivation and Context
We've agreed to use the Godaddy logger for structured JSON logging, which we are now rolling out to all the Java services.

# What has changed
Replaced all the `@Slf4j` annotations. Updated the logback.xml config.

# How to test?
Run with CLOUD profile and check that the logs are coming out in the correct JSON format.

# Links
Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

Architecture decision: https://github.com/ONSdigital/sdc/blob/master/doc/architecture/decisions/godaddy-structured-json-logging-java.md