### PR TITLE
Init JSON logging in PostConstruct method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ctp.common</groupId>
 			<artifactId>framework</artifactId>
-			<version>10.49.16</version>
+			<version>10.49.17</version>
 		</dependency>
 		<!-- END -->
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ctp.response.sample;
 
 import com.godaddy.logging.LoggingConfigs;
+import javax.annotation.PostConstruct;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -42,7 +42,7 @@ import uk.gov.ons.ctp.response.sample.service.state.SampleSvcStateTransitionMana
 @EnableJpaRepositories(basePackages = {"uk.gov.ons.ctp.response"})
 @EntityScan("uk.gov.ons.ctp.response")
 @ImportResource("springintegration/main.xml")
-public class SampleSvcApplication implements CommandLineRunner {
+public class SampleSvcApplication {
 
   @Autowired private StateTransitionManagerFactory stateTransitionManager;
 
@@ -57,8 +57,8 @@ public class SampleSvcApplication implements CommandLineRunner {
     SpringApplication.run(SampleSvcApplication.class, args);
   }
 
-  @Override
-  public void run(String... args) throws Exception {
+  @PostConstruct
+  public void initJsonLogging() {
     if (appConfig.getLogging().isUseJson()) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }


### PR DESCRIPTION
# Motivation and Context
Bug discovered by @ajmaddaford in CI-latest where JSON not being used for key-value pairs.

# What has changed
Instead of flipping logging to use JSON in a `CommandLineRunner.run()` method, we're using a `@Postconstruct` instead, which should always fire.

# How to test?
Run with `--spring.profiles.active=cloud` or hack the `application.yml` to set `CLOUD` logger and `useJson=true`

# Links
Related Trello card: https://trello.com/c/KNOUa0pq/349-update-logging-in-all-java-services-to-use-key-value-pairs