### PR TITLE
Add endpoint to get count of sample units

### DIFF
--- a/API.md
+++ b/API.md
@@ -39,8 +39,8 @@ This page documents the Sample service API endpoints. Apart from the Service Inf
 
 An `HTTP 201 Created` status code is returned if the sample unit request creation was a success. An `HTTP 400 Bad Request` is returned if any of the required parameters are missing, or if a sample unit request already exists for the same criteria.
 
-## Get Sample Summary Size Request
-* `GET /samples/samplecount?sampleSummaryId={id}` gets the total number of sample units.
+## Get Sample Summary Unit Count Request
+* `GET /samples/count?sampleSummaryId={id}` gets the total number of sample units.
 
 ### Example JSON Response
 ```json

--- a/API.md
+++ b/API.md
@@ -39,17 +39,8 @@ This page documents the Sample service API endpoints. Apart from the Service Inf
 
 An `HTTP 201 Created` status code is returned if the sample unit request creation was a success. An `HTTP 400 Bad Request` is returned if any of the required parameters are missing, or if a sample unit request already exists for the same criteria.
 
-## Get Sample Unit Size Request
-* `POST /samples/sampleunitsize` gets the total number of sample units.
-
-**Required parameters:** `sampleSummaryUUIDList` array of sample unit IDs to total up.
-
-### Example JSON Request
-```json
-{
-  "sampleSummaryUUIDList": ["14fb3e68-4dca-46db-bf49-04b84e07e77c"]
-}
-```
+## Get Sample Summary Size Request
+* `GET /samples/samplecount?sampleSummaryId={id}` gets the total number of sample units.
 
 ### Example JSON Response
 ```json

--- a/API.md
+++ b/API.md
@@ -39,6 +39,27 @@ This page documents the Sample service API endpoints. Apart from the Service Inf
 
 An `HTTP 201 Created` status code is returned if the sample unit request creation was a success. An `HTTP 400 Bad Request` is returned if any of the required parameters are missing, or if a sample unit request already exists for the same criteria.
 
+## Get Sample Unit Size Request
+* `POST /samples/sampleunitsize` gets the total number of sample units.
+
+**Required parameters:** `sampleSummaryUUIDList` array of sample unit IDs to total up.
+
+### Example JSON Request
+```json
+{
+  "sampleSummaryUUIDList": ["14fb3e68-4dca-46db-bf49-04b84e07e77c"]
+}
+```
+
+### Example JSON Response
+```json
+{
+  "sampleUnitsTotal": "666"
+}
+```
+
+An `HTTP 200 OK` status code is returned if the request could be successfully processed. Errors if sample units don't exist.
+
 ## Upload Sample File
 * `POST /samples/{type}/fileupload` uploads a sample csv file.
 

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
 			<plugin>
 				<groupId>com.spotify</groupId>
 				<artifactId>dockerfile-maven-plugin</artifactId>
-				<version>1.3.4</version>
+				<version>1.4.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-solr</artifactId>
-		</dependency>
-		
+
 		<!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-sleuth-zipkin -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -102,7 +98,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ctp.product</groupId>
 			<artifactId>samplesvc-api</artifactId>
-			<version>10.49.18</version>
+			<version>10.49.19</version>
 		</dependency>
 		<dependency>
 			<groupId>uk.gov.ons.ctp.product</groupId>
@@ -133,10 +129,6 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>redis.clients</groupId>
-			<artifactId>jedis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.liquibase</groupId>

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/DataGrid.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/DataGrid.java
@@ -9,6 +9,5 @@ import net.sourceforge.cobertura.CoverageIgnore;
 public class DataGrid {
   private String address;
   private String password;
-  private Integer lockTimeToWaitSeconds;
   private Integer lockTimeToLiveSeconds;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -36,7 +36,6 @@ import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreati
 import uk.gov.ons.ctp.response.sample.representation.SampleAttributesDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
@@ -105,32 +104,6 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
             .toString();
 
     return ResponseEntity.created(URI.create(newResourceUrl)).body(sampleUnitsRequest);
-  }
-
-  @RequestMapping(
-      value = "/sampleunitsize",
-      method = RequestMethod.POST,
-      consumes = "application/json")
-  public ResponseEntity<SampleUnitsRequestDTO> getSampleUnitSize(
-      final @Valid @RequestBody SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO,
-      BindingResult bindingResult)
-      throws InvalidRequestException {
-    log.with("sample_unit_size_request", sampleUnitSizeRequestDTO)
-        .debug("Entering getSampleUnitSize");
-
-    if (bindingResult.hasErrors()) {
-      throw new InvalidRequestException("Binding errors for create action: ", bindingResult);
-    }
-
-    int sampleUnitsTotal = 0;
-
-    for (UUID sampleSummaryID : sampleUnitSizeRequestDTO.getSampleSummaryUUIDList()) {
-      sampleUnitsTotal += sampleService.getSampleSummaryUnitCount(sampleSummaryID);
-    }
-
-    SampleUnitsRequestDTO sampleUnitsRequest = new SampleUnitsRequestDTO(sampleUnitsTotal);
-
-    return ResponseEntity.ok(sampleUnitsRequest);
   }
 
   /**
@@ -227,6 +200,21 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     SampleSummaryDTO result = mapperFacade.map(sampleSummary, SampleSummaryDTO.class);
 
     return ResponseEntity.ok(result);
+  }
+
+  @RequestMapping(value = "/samplecount", method = RequestMethod.GET)
+  public ResponseEntity<SampleUnitsRequestDTO> getSampleSummaryUnitCount(
+      @RequestParam(value = "sampleSummaryId") List<UUID> sampleSummaryIdList) {
+
+    int sampleUnitsTotal = 0;
+
+    for (UUID sampleSummaryId : sampleSummaryIdList) {
+      sampleUnitsTotal += sampleService.getSampleSummaryUnitCount(sampleSummaryId);
+    }
+
+    SampleUnitsRequestDTO sampleUnitsRequest = new SampleUnitsRequestDTO(sampleUnitsTotal);
+
+    return ResponseEntity.ok(sampleUnitsRequest);
   }
 
   @RequestMapping(value = "{id}", method = RequestMethod.GET)

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -113,8 +113,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       consumes = "application/json")
   public ResponseEntity<SampleUnitsRequestDTO> getSampleUnitSize(
       final @Valid @RequestBody SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO,
-      BindingResult bindingResult)
-      throws CTPException, InvalidRequestException {
+      BindingResult bindingResult) throws InvalidRequestException {
     log.with("sample_unit_size_request", sampleUnitSizeRequestDTO)
         .debug("Entering getSampleUnitSize");
 
@@ -124,11 +123,10 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
 
     int sampleUnitsTotal = 0;
 
-    List<UUID> sampleSummaryIds = sampleUnitSizeRequestDTO.getSampleSummaryUUIDList();
-
-    for (UUID sampleSummaryID : sampleSummaryIds) {
+    for (UUID sampleSummaryID : sampleUnitSizeRequestDTO.getSampleSummaryUUIDList()) {
       sampleUnitsTotal += sampleService.getSampleSummaryUnitCount(sampleSummaryID);
     }
+
     SampleUnitsRequestDTO sampleUnitsRequest = new SampleUnitsRequestDTO(sampleUnitsTotal);
 
     return ResponseEntity.ok(sampleUnitsRequest);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -202,7 +202,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     return ResponseEntity.ok(result);
   }
 
-  @RequestMapping(value = "/samplecount", method = RequestMethod.GET)
+  @RequestMapping(value = "/count", method = RequestMethod.GET)
   public ResponseEntity<SampleUnitsRequestDTO> getSampleSummaryUnitCount(
       @RequestParam(value = "sampleSummaryId") List<UUID> sampleSummaryIdList) {
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -36,6 +36,7 @@ import uk.gov.ons.ctp.response.sample.representation.CollectionExerciseJobCreati
 import uk.gov.ons.ctp.response.sample.representation.SampleAttributesDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitSizeRequestDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import validation.BusinessSampleUnit;
@@ -104,6 +105,33 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
             .toString();
 
     return ResponseEntity.created(URI.create(newResourceUrl)).body(sampleUnitsRequest);
+  }
+
+  @RequestMapping(
+      value = "/sampleunitsize",
+      method = RequestMethod.POST,
+      consumes = "application/json")
+  public ResponseEntity<SampleUnitsRequestDTO> getSampleUnitSize(
+      final @Valid @RequestBody SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO,
+      BindingResult bindingResult)
+      throws CTPException, InvalidRequestException {
+    log.with("sample_unit_size_request", sampleUnitSizeRequestDTO)
+        .debug("Entering getSampleUnitSize");
+
+    if (bindingResult.hasErrors()) {
+      throw new InvalidRequestException("Binding errors for create action: ", bindingResult);
+    }
+
+    int sampleUnitsTotal = 0;
+
+    List<UUID> sampleSummaryIds = sampleUnitSizeRequestDTO.getSampleSummaryUUIDList();
+
+    for (UUID sampleSummaryID : sampleSummaryIds) {
+      sampleUnitsTotal += sampleService.getSampleSummaryUnitCount(sampleSummaryID);
+    }
+    SampleUnitsRequestDTO sampleUnitsRequest = new SampleUnitsRequestDTO(sampleUnitsTotal);
+
+    return ResponseEntity.ok(sampleUnitsRequest);
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -113,7 +113,8 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       consumes = "application/json")
   public ResponseEntity<SampleUnitsRequestDTO> getSampleUnitSize(
       final @Valid @RequestBody SampleUnitSizeRequestDTO sampleUnitSizeRequestDTO,
-      BindingResult bindingResult) throws InvalidRequestException {
+      BindingResult bindingResult)
+      throws InvalidRequestException {
     log.with("sample_unit_size_request", sampleUnitSizeRequestDTO)
         .debug("Entering getSampleUnitSize");
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -2,10 +2,7 @@ package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.redisson.api.RLock;
@@ -31,6 +28,8 @@ public class SampleUnitDistributor {
   private static final Logger log = LoggerFactory.getLogger(SampleUnitDistributor.class);
 
   private static final String LOCK_PREFIX = "SampleCollexJob-";
+
+  private boolean hasErrors;
 
   @Autowired private AppConfig appConfig;
 
@@ -78,18 +77,27 @@ public class SampleUnitDistributor {
   }
 
   private void processJob(CollectionExerciseJob job) {
-    List<SampleUnit> mappedSampleUnits =
-        getMappedSampleUnits(job.getSampleSummaryId(), job.getCollectionExerciseId().toString());
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(job.getSampleSummaryId());
 
-    boolean hasErrors = false;
+    hasErrors = false;
 
-    for (SampleUnit msu : mappedSampleUnits) {
-      try {
-        sampleUnitSender.sendSampleUnit(msu);
-      } catch (CTPException e) {
-        hasErrors = true;
-        log.with("sample_unit_id", msu.getId())
-            .error("Failed to send a sample unit to queue and update state with ID", e);
+    if (sampleSummary.getState() == SampleState.ACTIVE) {
+      try (Stream<uk.gov.ons.ctp.response.sample.domain.model.SampleUnit> sampleUnits =
+          sampleUnitRepository.findBySampleSummaryFKAndState(
+              sampleSummary.getSampleSummaryPK(), SampleUnitState.PERSISTED)) {
+        sampleUnits.forEach(
+            su -> {
+              SampleUnit mappedSampleUnit =
+                  sampleUnitMapper.mapSampleUnit(su, job.getCollectionExerciseId().toString());
+
+              try {
+                sampleUnitSender.sendSampleUnit(mappedSampleUnit);
+              } catch (CTPException e) {
+                hasErrors = true;
+                log.with("sample_unit_id", mappedSampleUnit.getId())
+                    .error("Failed to send a sample unit to queue and update state", e);
+              }
+            });
       }
     }
 
@@ -97,28 +105,5 @@ public class SampleUnitDistributor {
       job.setJobComplete(true);
       collectionExerciseJobRepository.saveAndFlush(job);
     }
-  }
-
-  private List<SampleUnit> getMappedSampleUnits(UUID sampleSummaryId, String collectionExerciseId) {
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId);
-
-    if (sampleSummary.getState() != SampleState.ACTIVE) {
-      return Collections.EMPTY_LIST;
-    }
-
-    List<SampleUnit> mappedSampleUnits = new LinkedList<>();
-
-    try (Stream<uk.gov.ons.ctp.response.sample.domain.model.SampleUnit> sampleUnits =
-        sampleUnitRepository.findBySampleSummaryFKAndState(
-            sampleSummary.getSampleSummaryPK(), SampleUnitState.PERSISTED)) {
-      sampleUnits.forEach(
-          su -> {
-            SampleUnit mappedSampleUnit = sampleUnitMapper.mapSampleUnit(su, collectionExerciseId);
-
-            mappedSampleUnits.add(mappedSampleUnit);
-          });
-    }
-
-    return mappedSampleUnits;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -201,21 +201,17 @@ public class SampleService {
   }
 
   public int getSampleSummaryUnitCount(UUID sampleSummaryId) {
-    int sampleUnitsTotal = 0;
-
     SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId);
 
-    if (sampleSummary != null) {
-      if (sampleSummary.getTotalSampleUnits() != null) {
-        sampleUnitsTotal = sampleSummary.getTotalSampleUnits().intValue();
-      } else {
-        throw new IllegalStateException(
-            String.format("Sample summary %s has no total sample units set", sampleSummaryId));
-      }
-    } else {
+    if (sampleSummary == null) {
       throw new IllegalArgumentException(
           String.format("Sample summary %s cannot be found", sampleSummaryId));
+    } else if (sampleSummary.getTotalSampleUnits() == null) {
+      throw new IllegalStateException(
+          String.format("Sample summary %s has no total sample units set", sampleSummaryId));
     }
+
+    int sampleUnitsTotal = sampleSummary.getTotalSampleUnits().intValue();
 
     return sampleUnitsTotal;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -200,6 +200,26 @@ public class SampleService {
     return sampleUnitsTotal;
   }
 
+  public int getSampleSummaryUnitCount(UUID sampleSummaryId) {
+    int sampleUnitsTotal = 0;
+
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId);
+
+    if (sampleSummary != null) {
+      if (sampleSummary.getTotalSampleUnits() != null) {
+        sampleUnitsTotal = sampleSummary.getTotalSampleUnits().intValue();
+      } else {
+        throw new IllegalStateException(
+            String.format("Sample summary %s has no total sample units set", sampleSummaryId));
+      }
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Sample summary %s cannot be found", sampleSummaryId));
+    }
+
+    return sampleUnitsTotal;
+  }
+
   public SampleSummary ingest(
       final SampleSummary sampleSummary, final MultipartFile file, final String type)
       throws Exception {

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -107,9 +107,6 @@ redis:
 
 data-grid:
   address: ${cloud.services.redis.connection.host}:6379
-  list-time-to-live-seconds: 600
-  list-time-to-wait-seconds: 600
-  lock-time-to-live-seconds: 600
 
 messaging:
   pubMaxAttempts: 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,7 +118,6 @@ redis:
 
 data-grid:
   address: localhost:7379
-  lock-time-to-wait-seconds: 30
   lock-time-to-live-seconds: 3600
 
 messaging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,7 +119,7 @@ redis:
 data-grid:
   address: localhost:7379
   lock-time-to-wait-seconds: 30
-  lock-time-to-live-seconds: 600
+  lock-time-to-live-seconds: 3600
 
 messaging:
   backoffInitial: 5000

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -407,7 +407,7 @@ public class SampleEndpointIT {
 
     String url =
         String.format(
-            "http://localhost:%d/samples/samplecount?sampleSummaryId=%s", port, sampleSummaryId);
+            "http://localhost:%d/samples/count?sampleSummaryId=%s", port, sampleSummaryId);
 
     HttpResponse<SampleUnitsRequestDTO> response =
         Unirest.get(url)

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -401,15 +401,18 @@ public class SampleEndpointIT {
                 "file")
             .asObject(SampleSummary.class);
 
-    String sampleUnitId = sampleSummary.getBody().getId().toString();
+    String sampleSummaryId = sampleSummary.getBody().getId().toString();
 
     uploadFinishedMessageListener.take();
 
+    String url =
+        String.format(
+            "http://localhost:%d/samples/samplecount?sampleSummaryId=%s", port, sampleSummaryId);
+
     HttpResponse<SampleUnitsRequestDTO> response =
-        Unirest.post(String.format("http://localhost:%d/samples/sampleunitsize", port))
+        Unirest.get(url)
             .header("Content-Type", "application/json")
             .basicAuth("admin", "secret")
-            .body(String.format("{ \"sampleSummaryUUIDList\" : [\"%s\"] }", sampleUnitId))
             .asObject(SampleUnitsRequestDTO.class);
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -419,7 +422,7 @@ public class SampleEndpointIT {
   private SampleSummaryDTO loadSocialSample(String sampleFile)
       throws UnirestException, IOException, InterruptedException {
     HttpResponse<SampleSummary> sampleSummaryResponse =
-        Unirest.post("http://localhost:" + port + "/samples/SOCIAL/fileupload")
+        Unirest.post(String.format("http://localhost:%d/samples/SOCIAL/fileupload", port))
             .basicAuth("admin", "secret")
             .field(
                 "file",

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -173,8 +173,7 @@ public class SampleEndpointUnitTest {
   public void getSampleUnitSizeOneSummary() throws Exception {
     when(sampleService.getSampleSummaryUnitCount(any())).thenReturn(666);
 
-    String url =
-        String.format("/samples/samplecount?sampleSummaryId=%s", UUID.randomUUID().toString());
+    String url = String.format("/samples/count?sampleSummaryId=%s", UUID.randomUUID().toString());
 
     ResultActions actions = mockMvc.perform(get(url));
 
@@ -188,7 +187,7 @@ public class SampleEndpointUnitTest {
 
     String url =
         String.format(
-            "/samples/samplecount?sampleSummaryId=%s&sampleSummaryId=%s",
+            "/samples/count?sampleSummaryId=%s&sampleSummaryId=%s",
             UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
     ResultActions actions = mockMvc.perform(get(url));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -47,10 +47,6 @@ public class SampleEndpointUnitTest {
       "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8392f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"2012-12-13T12:12:12.000+0000\", \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
   private static final String SAMPLE_INVALIDJSON =
       "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8393f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"201.000+0000\" }";
-  private static final String SAMPLE_SUMMARIES_TO_COUNT_ONE =
-      "{ \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
-  private static final String SAMPLE_SUMMARIES_TO_COUNT_TWO =
-      "{ \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\",\"66467711-66eb-4e78-666c-1db8392f9666\"] }";
 
   @InjectMocks private SampleEndpoint sampleEndpoint;
 
@@ -177,9 +173,10 @@ public class SampleEndpointUnitTest {
   public void getSampleUnitSizeOneSummary() throws Exception {
     when(sampleService.getSampleSummaryUnitCount(any())).thenReturn(666);
 
-    ResultActions actions =
-        mockMvc.perform(
-            postJson(String.format("/samples/sampleunitsize"), SAMPLE_SUMMARIES_TO_COUNT_ONE));
+    String url =
+        String.format("/samples/samplecount?sampleSummaryId=%s", UUID.randomUUID().toString());
+
+    ResultActions actions = mockMvc.perform(get(url));
 
     actions.andExpect(status().isOk());
     actions.andExpect(jsonPath("$.sampleUnitsTotal", is(666)));
@@ -189,9 +186,12 @@ public class SampleEndpointUnitTest {
   public void getSampleUnitSizeTwoSummaries() throws Exception {
     when(sampleService.getSampleSummaryUnitCount(any())).thenReturn(33).thenReturn(66);
 
-    ResultActions actions =
-        mockMvc.perform(
-            postJson(String.format("/samples/sampleunitsize"), SAMPLE_SUMMARIES_TO_COUNT_TWO));
+    String url =
+        String.format(
+            "/samples/samplecount?sampleSummaryId=%s&sampleSummaryId=%s",
+            UUID.randomUUID().toString(), UUID.randomUUID().toString());
+
+    ResultActions actions = mockMvc.perform(get(url));
 
     actions.andExpect(status().isOk());
     actions.andExpect(jsonPath("$.sampleUnitsTotal", is(99)));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -47,6 +47,10 @@ public class SampleEndpointUnitTest {
       "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8392f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"2012-12-13T12:12:12.000+0000\", \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
   private static final String SAMPLE_INVALIDJSON =
       "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8393f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"201.000+0000\" }";
+  private static final String SAMPLE_SUMMARIES_TO_COUNT_ONE =
+      "{ \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
+  private static final String SAMPLE_SUMMARIES_TO_COUNT_TWO =
+      "{ \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\",\"66467711-66eb-4e78-666c-1db8392f9666\"] }";
 
   @InjectMocks private SampleEndpoint sampleEndpoint;
 
@@ -167,5 +171,29 @@ public class SampleEndpointUnitTest {
     getAttribs.andExpect(status().isOk());
 
     assertThat(sampleAttributesDTO.getId()).isEqualTo(id);
+  }
+
+  @Test
+  public void getSampleUnitSizeOneSummary() throws Exception {
+    when(sampleService.getSampleSummaryUnitCount(any())).thenReturn(666);
+
+    ResultActions actions =
+        mockMvc.perform(
+            postJson(String.format("/samples/sampleunitsize"), SAMPLE_SUMMARIES_TO_COUNT_ONE));
+
+    actions.andExpect(status().isOk());
+    actions.andExpect(jsonPath("$.sampleUnitsTotal", is(666)));
+  }
+
+  @Test
+  public void getSampleUnitSizeTwoSummaries() throws Exception {
+    when(sampleService.getSampleSummaryUnitCount(any())).thenReturn(33).thenReturn(66);
+
+    ResultActions actions =
+        mockMvc.perform(
+            postJson(String.format("/samples/sampleunitsize"), SAMPLE_SUMMARIES_TO_COUNT_TWO));
+
+    actions.andExpect(status().isOk());
+    actions.andExpect(jsonPath("$.sampleUnitsTotal", is(99)));
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -62,13 +62,12 @@ public class SampleUnitDistributorTest {
     MockitoAnnotations.initMocks(this);
 
     DataGrid dataGrid = new DataGrid();
-    dataGrid.setLockTimeToLiveSeconds(30);
-    dataGrid.setLockTimeToWaitSeconds(600);
+    dataGrid.setLockTimeToLiveSeconds(60);
     when(appConfig.getDataGrid()).thenReturn(dataGrid);
 
     lock = mock(RLock.class);
     when(redissonClient.getFairLock(any())).thenReturn(lock);
-    when(lock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+    when(lock.tryLock(anyLong(), any(TimeUnit.class))).thenReturn(true);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -316,4 +316,30 @@ public class SampleServiceTest {
     // Then
     verify(sampleOutboundPublisher, times(1)).sampleUploadStarted(any());
   }
+
+  @Test
+  public void getSampleSummaryUnitCountHappyPath() {
+    SampleSummary newSummary = createSampleSummary(5, 2);
+    when(sampleSummaryRepository.findById(any())).thenReturn(newSummary);
+
+    int actualResult = sampleService.getSampleSummaryUnitCount(newSummary.getId());
+
+    assertEquals(5, actualResult);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void getSampleSummaryUnitCountSampleSummaryNonExistent() {
+    when(sampleSummaryRepository.findById(any())).thenReturn(null);
+
+    sampleService.getSampleSummaryUnitCount(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getSampleSummaryUnitCountSampleSummaryNullSize() {
+    SampleSummary newSummary = createSampleSummary(5, 2);
+    newSummary.setTotalSampleUnits(null);
+    when(sampleSummaryRepository.findById(any())).thenReturn(newSummary);
+
+    sampleService.getSampleSummaryUnitCount(newSummary.getId());
+  }
 }


### PR DESCRIPTION
# Motivation and Context
Presently the Collection Exercise service doesn't know how many sample units it expects to be sent by the Sample service until it requests the sample units to be sent, which causes a race condition - if the sample units start arriving before Collex has managed to store the expected number to the database.

This was causing intermittent failures in the CI pipeline and in production, and a temporary fix was to ignore the count check if we didn't have an expected value, but this fix was less than ideal, because the race condition still potentially existed for very small sample sizes.

This fix is intended to close all the loopholes by asking for the number of expected sample units _before_ they start to be sent by the Sample service. This is **one of three** related PRs.

# What has changed
Added a new REST API endpoing so that Collex can make the request for the sample size to the Sample service.

# How to test?
Upload some samples of different sizes and then use swagger-ui (`http://localhost:8125/swagger-ui.html`) to test the endpoint.

# Links
Trello: https://trello.com/c/DaKcP1zA/379-race-condition-fix-for-sample-collex-exchange-of-sample-data