### PR TITLE
Fix timezone specified in weird way

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -44,7 +44,7 @@ import uk.gov.ons.ctp.response.sample.service.SampleService;
 
 public class SampleEndpointUnitTest {
   private static final String SAMPLE_VALIDJSON =
-      "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8392f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"2012-12-13T12:12:12.000+0000\", \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
+      "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8392f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"2012-12-13T12:12:12.000Z\", \"sampleSummaryUUIDList\" : [\"c6467711-21eb-4e78-804c-1db8392f93fb\"] }";
   private static final String SAMPLE_INVALIDJSON =
       "{ \"collectionExerciseId\" : \"c6467711-21eb-4e78-804c-1db8393f93fb\", \"surveyRef\" : \"str1234\", \"exerciseDateTime\" : \"201.000+0000\" }";
 


### PR DESCRIPTION
# Motivation and Context
We're using more vanilla ISO8601 dates now, since a major bug was discovered where the dates were being mangled by a non-threadsafe date formatter. Not sure why we can't support the old date formats, but it's not really important.

# What has changed
Updated a test.

# How to test?
This is a part of a whole load of PRs attempting to fix a multithreading issue, causing mangled dates to be returned when the REST API is concurrently called by 3 or 4 users, which is bad.

# Links
Trello: https://trello.com/c/bGt4TX2Q/405-bug-bad-dates-being-returned-by-java-services-under-load