### PR TITLE
Added undeprecated database platform instead of current one in place 

### DIFF
--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -63,7 +63,7 @@ spring:
     url: ${cloud.services.postgresql.connection.jdbcurl}
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     show-sql: false
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,7 +73,7 @@ spring:
     baseUrl: http://localhost:9411
     enabled: false
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
# Motivation and Context
This is an out of date module/dependency and it is recommended to use the alternative one in the PR instead.
This mainly provides support for 'if exists' in SQL for database for when we do database transactions/migrations etc.

# What has changed
Updated to use correct dependency

# How to test?
- `mvn clean install` and check if all builds successfully

# Links
Card: https://trello.com/c/QwluwHSN/509-upgrade-postgresql-hibernate-dialect-from-deprecated-to-v9-for-all-java-services-s