### PR TITLE
Fix multithreading bug with CSV parsing

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -2,6 +2,9 @@ package uk.gov.ons.ctp.response.sample;
 
 import com.godaddy.logging.LoggingConfigs;
 import javax.annotation.PostConstruct;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -145,5 +148,11 @@ public class SampleSvcApplication {
   @Primary
   public CustomObjectMapper customObjectMapper() {
     return new CustomObjectMapper();
+  }
+
+  @Bean
+  public Validator csvIngestValidator() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    return factory.getValidator();
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterBusinessTest.java
@@ -11,6 +11,8 @@ import static uk.gov.ons.ctp.response.sample.TestFiles.getTestFileFromString;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import javax.validation.Validation;
+import javax.validation.Validator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,6 +47,9 @@ public class CsvIngesterBusinessTest {
   @Mock private SampleService sampleService;
 
   @Mock private PartyPublisher partyPublisher;
+
+  @Spy
+  private Validator csvIngestValidator = Validation.buildDefaultValidatorFactory().getValidator();
 
   @Captor public ArgumentCaptor<List<BusinessSampleUnit>> argumentCaptor;
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/CsvIngesterCensusTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.validation.Validation;
+import javax.validation.Validator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,6 +38,9 @@ public class CsvIngesterCensusTest {
   @InjectMocks private SampleEndpoint sampleEndpoint;
 
   @Mock private SampleService sampleService;
+
+  @Spy
+  private Validator csvIngestValidator = Validation.buildDefaultValidatorFactory().getValidator();
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 


### PR DESCRIPTION
# Motivation and Context
The Sample service is capable of processing up to 5 samples simultaneously - using multithreading - but the Liquibase CSV parser is not thread-safe. This causes occasional failures of our parallel acceptance tests. Also this is a **production** bug, which would cause issues if two large-ish samples were uploaded at roughly the same time.

# What has changed
Use of the `@Cachable` annotation was being ignored by Spring, because AOP cannot work when one function calls another within the same class.

Thread-safety has been achieved using a `synchronised` block around the piece of code that isn't thread-safe.

# How to test?
This has been extensively tested during the performance enhancement work. To test it, upload two large samples into two different collection exercises at roughly the same time. They should process without an issue.

# Links
Trello: https://trello.com/c/HwQhlfwm/568-bug-sample-service-uploads-are-not-thread-safe-and-will-throw-false-validation-errors
