### PR TITLE
Automate census docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
   docker push "$DESTINATION_IMAGE_NAME";
@@ -32,4 +32,4 @@ cache:
 
 branches:
   only:
-    - automate-census-docker-build
+    - rm-census

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ language: java
 jdk: openjdk8
 
 env:
-  - SOURCE_IMAGE_NAME="samplesvc" DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-samplesvc"
+  global:
+  - SOURCE_IMAGE_NAME="samplesvc"
+  - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-samplesvc"
 
 before_install:
   - cp .maven.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,3 @@ cache:
 branches:
   only:
     - rm-census
-    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag samplesvc "${DOCKER_GCP_LOCATION}"/samplesvc;
   docker push "${DOCKER_GCP_LOCATION}"/samplesvc;
@@ -34,4 +34,5 @@ cache:
 
 branches:
   only:
-  - rm-census
+    - rm-census
+    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,18 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-    docker push sdcplatform/samplesvc;
-    fi
-  - bash <(curl -s https://codecov.io/bash)
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker tag samplesvc "${DOCKER_GCP_LOCATION}"/samplesvc;
+  docker push "${DOCKER_GCP_LOCATION}"/samplesvc;
+  fi
+- bash <(curl -s https://codecov.io/bash)
 
 notifications:
   slack:
     rooms:
       secure: V+Uvej5O5wvnrDwpD41Dj4f/EGUlVqHX3UaW99njf//gl8yCezXcnHS0G8Wkdhi2SE2ss0I2TwQpDkQzCVtR5/RL+J8oXpyOJFFiZnhCworNHQniwMigHY5eoSIQCwiKe6wJeccsdQB67XPlhI4Q0tWgh/sDvwOs3X8sptvHpTdtBBs8oVkpqMYIg/PDPTrYpbPDxiUB0eGws41eTplR7H08Lp9Gzz1rEMak4zHCuae4idJWTpcUga/LnreKpisBHnvNA7Iadyv6LRP2AP5O7gZaL27f1KL5kewk0KZndJ1qyTZv4r5CyI20V1C7ja4wV7zm11s7MFxmGHidYtKUsMx5G53kjZNsoYMgFjnbmt1LfOFiMh8Me7WN7TsmiKePGHrCDf9LQTFhzgE5OFx8dzPKMrikKlzZ0eoVKPPbKm4/WQLErBeb9MkITEsYy5ATw/Mpx2eCIuQdM+E91nz8HYVJn1Pud/duIMlQOiQKVTgvz0c2LDLCaIEK7/dzwNsVvE7IEaXOzz7BQ2P3583CP0PV9SqrnaOswcIR1QJ6w4SeIJ1FvmaFhOE/ClaUnHdq0J4KY2/HXELSSa9HlV3l73d+XY3TP9m6vjEYz+esp8zevA33CUn8D6hl7+/ds7OdxLP9AiXrTHcP1vu/bAcEBEHgqz2YRjteOdCvVtT5MLU=
-    on_failure: always
+    on_failure: never
     on_success: never
 
 cache:
@@ -33,4 +34,4 @@ cache:
 
 branches:
   only:
-  - master
+  - rm-census

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ cache:
 
 branches:
   only:
-    - rm-census
+    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
 language: java
 jdk: openjdk8
 
+env:
+  - SOURCE_IMAGE_NAME="samplesvc" DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-samplesvc"
+
 before_install:
   - cp .maven.settings.xml $HOME/.m2/settings.xml
   - mvn fmt:check
@@ -16,8 +19,8 @@ script: mvn verify cobertura:cobertura-integration-test
 after_success:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker tag samplesvc "${DOCKER_GCP_LOCATION}"/samplesvc;
-  docker push "${DOCKER_GCP_LOCATION}"/samplesvc;
+  docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
+  docker push "$DESTINATION_IMAGE_NAME";
   fi
 - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,12 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag samplesvc "${DOCKER_GCP_LOCATION}"/samplesvc;
   docker push "${DOCKER_GCP_LOCATION}"/samplesvc;
   fi
 - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  slack:
-    rooms:
-      secure: V+Uvej5O5wvnrDwpD41Dj4f/EGUlVqHX3UaW99njf//gl8yCezXcnHS0G8Wkdhi2SE2ss0I2TwQpDkQzCVtR5/RL+J8oXpyOJFFiZnhCworNHQniwMigHY5eoSIQCwiKe6wJeccsdQB67XPlhI4Q0tWgh/sDvwOs3X8sptvHpTdtBBs8oVkpqMYIg/PDPTrYpbPDxiUB0eGws41eTplR7H08Lp9Gzz1rEMak4zHCuae4idJWTpcUga/LnreKpisBHnvNA7Iadyv6LRP2AP5O7gZaL27f1KL5kewk0KZndJ1qyTZv4r5CyI20V1C7ja4wV7zm11s7MFxmGHidYtKUsMx5G53kjZNsoYMgFjnbmt1LfOFiMh8Me7WN7TsmiKePGHrCDf9LQTFhzgE5OFx8dzPKMrikKlzZ0eoVKPPbKm4/WQLErBeb9MkITEsYy5ATw/Mpx2eCIuQdM+E91nz8HYVJn1Pud/duIMlQOiQKVTgvz0c2LDLCaIEK7/dzwNsVvE7IEaXOzz7BQ2P3583CP0PV9SqrnaOswcIR1QJ6w4SeIJ1FvmaFhOE/ClaUnHdq0J4KY2/HXELSSa9HlV3l73d+XY3TP9m6vjEYz+esp8zevA33CUn8D6hl7+/ds7OdxLP9AiXrTHcP1vu/bAcEBEHgqz2YRjteOdCvVtT5MLU=
-    on_failure: never
-    on_success: never
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 						</goals>
 						<phase>package</phase>
 						<configuration>
-							<repository>sdcplatform/${project.artifactId}</repository>
+							<repository>${project.artifactId}</repository>
 							<buildArgs>
 								<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
 							</buildArgs>


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition and "branches only" section in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/dC6sEWqE/443-set-up-automated-docker-image-build)