### PR TITLE
documented redundant /sampleunits endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -161,3 +161,21 @@ A `HTTP 201 Created` status code is returned if the sample csv is successfully u
     }
 }
 ```
+
+## Find Sample Units by Postcode
+* `GET /samples/sampleunits?postcode={postcode}` get Sample Units by Postcode
+
+### Example JSON Response
+```json
+[
+
+    {
+    "error":{
+    "code":"SYSTEM_ERROR",
+    "timestamp":"20190522122749865",
+    "message":"Required String parameter 'postcode' is not present"}
+    }
+]
+```
+
+NOTE: This endpoint wants a postcode as a query. However, the database does not appear to keep any valid postcodes. As such, this endpoint seems to only return errors, and may be redundant.


### PR DESCRIPTION
# Motivation and Context
I was checking the endpoints for this service and noticed that /sampleunits did not have documentation. When I tried to access the endpoint, however, I realised that it is necessary to pass in a postcode, which the Postgres database doesn't keep. As such, I don't think it is possible to use this endpoint. I have checked a few of the other services and this endpoint does not appear to be used, so I left a note to mark the endpoint as potentially redundant.

# What has changed
Updated API.md file.

# Links
[Trello card](https://trello.com/c/xZYE0DQO)