### PR TITLE
added generated helm templates

### DIFF
--- a/_infra/helm/.helmignore
+++ b/_infra/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/_infra/helm/Chart.yaml
+++ b/_infra/helm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: samplesvc
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 11.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 11.0.0

--- a/_infra/helm/Chart.yaml
+++ b/_infra/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: samplesvc
+name: sample
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 11.0.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge:
+      maxUnavailable:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      env: "{{ .Values.env }}"
+      version: "v1.2"
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        env: "{{ .Values.env }}"
+        version: "v1.2"
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "eu.gcr.io/rm-ras-sandbox/{{ .Values.image.repositoryName }}:{{ .Values.image.tag }}"
+          imagePullPolicy:
+          ports:
+            - name: http-server
+              containerPort: 8095
+          readinessProbe:
+            httpGet:
+              path: /info
+              port: 8095
+            initialDelaySeconds: 100
+            periodSeconds: 20
+            failureThreshold: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /info
+              port: 8095
+            initialDelaySeconds: 110
+            periodSeconds: 20
+            failureThreshold: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          env:
+          - name: DB_HOST
+            value: $(POSTGRES_SERVICE_HOST)
+          - name: DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: db-port
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: db-name
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: username
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: password
+          - name: SECURITY_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-user
+          - name: SECURITY_USER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-password
+          - name: RABBITMQ_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: rabbitmq
+                key: rabbitmq-username
+          - name: RABBITMQ_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: rabbitmq
+                key: rabbitmq-password
+          - name: SERVER_PORT
+            value: "8095"
+          - name: SECURITY_BASIC_ENABLED
+            value: "true"
+          - name: SPRING_DATASOURCE_URL
+            value: "jdbc:postgresql://$(DB_HOST):$(DB_PORT)/$(DB_NAME)?sslmode=disable"
+          - name: liquibase_url
+            value: "jdbc:postgresql://$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+          - name: RABBITMQ_PORT
+            value: "5672"
+          - name: RABBITMQ_HOST
+            value: "$(RABBITMQ_SERVICE_HOST)"
+          - name: REDIS_HOST
+            value: "$(REDIS_MASTER_SERVICE_HOST)"
+          - name: REDIS_PORT
+            value: "$(REDIS_MASTER_SERVICE_PORT)"
+          - name: DATA_GRID_ADDRESS
+            value: "$(REDIS_HOST):$(REDIS_PORT)"
+          - name: SFTP_HOST
+            value: "$(SFTP_SERVICE_HOST)"
+          - name: SFTP_PORT
+            value: "$(SFTP_SERVICE_PORT)"
+          - name: PARTY_SVC_CONNECTION_CONFIG_HOST
+            value: "$(RAS_PARTY_SERVICE_HOST)"
+          - name: PARTY_SVC_CONNECTION_CONFIG_PORT
+            value: "$(RAS_PARTY_SERVICE_PORT)"
+          - name: PARTY_SVC_CONNECTION_CONFIG_USERNAME
+            value: "$(SECURITY_USER_NAME)"
+          - name: PARTY_SVC_CONNECTION_CONFIG_PASSWORD
+            value: "$(SECURITY_USER_PASSWORD)"
+          - name: SAMPLE_UNIT_DISTRIBUTION_DELAY_MILLI_SECONDS
+            value: "1000"
+          - name: LIQUIBASE_USER
+            value: "$(DB_USERNAME)"
+          - name: LIQUIBASE_PASSWORD
+            value: "$(DB_PASSWORD)"
+          - name: SPRING_DATASOURCE_USERNAME
+            value: "$(DB_USERNAME)"
+          - name: SPRING_DATASOURCE_PASSWORD
+            value: "$(DB_PASSWORD)"
+          - name: SPRING_ZIPKIN_ENABLED
+            value: "true"
+          - name: SPRING_ZIPKIN_BASEURL
+            value: "http://$(ZIPKIN_SERVICE_HOST):$(ZIPKIN_SERVICE_PORT)/"
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2056Mi
+            requests:
+              cpu: 500m
+              memory: 1028Mi

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -13,17 +13,15 @@ spec:
     matchLabels:
       app: {{ .Chart.Name }}
       env: "{{ .Values.env }}"
-      version: "v1.2"
   template:
     metadata:
       labels:
         app: {{ .Chart.Name }}
         env: "{{ .Values.env }}"
-        version: "v1.2"
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "eu.gcr.io/rm-ras-sandbox/{{ .Values.image.repositoryName }}:{{ .Values.image.tag }}"
+          image: "eu.gcr.io/ons-rasrmbs-management/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
           imagePullPolicy:
           ports:
             - name: http-server

--- a/_infra/helm/templates/service.yaml
+++ b/_infra/helm/templates/service.yaml
@@ -8,5 +8,3 @@ spec:
   - port: {{ .Values.service.port }}
     protocol: TCP
     targetPort: {{ .Values.service.port }}
-  selector:
-    app: {{ include "common.name" . }}

--- a/_infra/helm/templates/service.yaml
+++ b/_infra/helm/templates/service.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: samplesvc
+  name: {{ .Chart.Name }}
 spec:
   type: ClusterIP
   ports:
   - port: {{ .Values.service.port }}
     protocol: TCP
     targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ .Chart.Name }}

--- a/_infra/helm/templates/service.yaml
+++ b/_infra/helm/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: samplesvc
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ include "common.name" . }}

--- a/_infra/helm/values.yaml
+++ b/_infra/helm/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+env: "dev"
+version: "v1.2"
+
+image:
+  tag: migration-sandbox
+  repository: eu.gcr.io/rm-ras-sandbox
+
+service:
+  port: 8095
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1028Mi"
+  limits:
+    cpu: "1000m"
+    memory: "2056Mi"

--- a/_infra/helm/values.yaml
+++ b/_infra/helm/values.yaml
@@ -1,11 +1,6 @@
 replicaCount: 1
 
 env: "dev"
-version: "v1.2"
-
-image:
-  tag: migration-sandbox
-  repository: eu.gcr.io/rm-ras-sandbox
 
 service:
   port: 8095


### PR DESCRIPTION
# Motivation and Context
Now that deployments via helm are possible, the helm charts needed to be move to their respective git repos.

# What has changed

Generated templates using ras-rm-terraform for service.yaml and deployment.yaml.

Created new folder called '_infra' in the root, and put the templates in a folder called 'helm'.

Overwrote the .yaml files.

# How to test?

Check that the _infra folder exists, and that the templates are present. They should be different from the ones in the 'samplesvc folder in ras-rm-terraform's root.

# Links
[Trello card](https://trello.com/c/7R8NMkz6)
