### PR TITLE
added devRepo

### DIFF
--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- if eq .Values.image.tag "latest"}}
           image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
           {{- else}}
-          image: "{{ .Values.image.name }}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.devRepo }}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
           {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/_infra/helm/sample/values.yaml
+++ b/_infra/helm/sample/values.yaml
@@ -7,6 +7,7 @@ rollingUpdate:
   maxUnavailable: 1
 
 image:
+  devRepo: eu.gcr.io/ons-rasrmbs-management
   name: eu.gcr.io/ons-rasrmbs-management
   tag: latest
   pullPolicy: Always


### PR DESCRIPTION
# Motivation and Context
The helm charts needed to have the option of selecting different repos when a developer is testing changes.

# What has changed

- The `deployment.yaml` now switches to the devRepo if the `latest` tag is not set.

- Added the devRepo to `values.yaml`. As of now, it is the same as the current image's repo, but will be different in prod and pre-prod.

# Links
[Trello card](https://trello.com/c/fLbRN0qG)