### PR TITLE
Remove godaddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,11 +192,6 @@
 			<artifactId>hibernate-types-5</artifactId>
 			<version>2.2.1</version>
 		</dependency>
-		<dependency>
-			<groupId>com.godaddy</groupId>
-			<artifactId>logging</artifactId>
-			<version>1.2.5</version>
-		</dependency>
 		<!-- END -->
 
 		<!-- Testing -->

--- a/src/main/java/libs/common/error/RestExceptionHandler.java
+++ b/src/main/java/libs/common/error/RestExceptionHandler.java
@@ -1,9 +1,11 @@
 package libs.common.error;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.stream.Collectors;
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -33,9 +35,7 @@ public class RestExceptionHandler {
    */
   @ExceptionHandler(CTPException.class)
   public ResponseEntity<?> handleCTPException(CTPException exception) {
-    log.with("fault", exception.getFault())
-        .with("exception_message", exception.getMessage())
-        .error("Uncaught CTPException", exception);
+    log.error("Uncaught CTPException", kv("exception", exception));
 
     HttpStatus status;
     switch (exception.getFault()) {
@@ -93,9 +93,8 @@ public class RestExceptionHandler {
             .map(e -> String.format("field=%s message=%s", e.getField(), e.getDefaultMessage()))
             .collect(Collectors.joining(","));
 
-    log.with("validation_errors", errors)
-        .with("source_message", ex.getSourceMessage())
-        .error("Unhandled InvalidRequestException", ex);
+    log.error(
+        "Unhandled InvalidRequestException", kv("validation_errors", errors), kv("exception", ex));
     CTPException ourException =
         new CTPException(CTPException.Fault.VALIDATION_FAILED, INVALID_JSON);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);
@@ -132,8 +131,10 @@ public class RestExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<?> handleMethodArgumentNotValidException(
       MethodArgumentNotValidException ex) {
-    log.with("parameter", ex.getParameter().getParameterName())
-        .error("Uncaught MethodArgumentNotValidException", ex);
+    log.error(
+        "Uncaught MethodArgumentNotValidException",
+        kv("parameter", ex.getParameter().getParameterName()),
+        kv("exception", ex));
     CTPException ourException =
         new CTPException(CTPException.Fault.VALIDATION_FAILED, INVALID_JSON);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);

--- a/src/main/java/libs/common/error/RestExceptionHandler.java
+++ b/src/main/java/libs/common/error/RestExceptionHandler.java
@@ -35,7 +35,7 @@ public class RestExceptionHandler {
    */
   @ExceptionHandler(CTPException.class)
   public ResponseEntity<?> handleCTPException(CTPException exception) {
-    log.error("Uncaught CTPException", kv("exception", exception));
+    log.error("Uncaught CTPException", exception);
 
     HttpStatus status;
     switch (exception.getFault()) {
@@ -93,8 +93,7 @@ public class RestExceptionHandler {
             .map(e -> String.format("field=%s message=%s", e.getField(), e.getDefaultMessage()))
             .collect(Collectors.joining(","));
 
-    log.error(
-        "Unhandled InvalidRequestException", kv("validation_errors", errors), kv("exception", ex));
+    log.error("Unhandled InvalidRequestException", kv("validation_errors", errors), ex);
     CTPException ourException =
         new CTPException(CTPException.Fault.VALIDATION_FAILED, INVALID_JSON);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);
@@ -134,7 +133,7 @@ public class RestExceptionHandler {
     log.error(
         "Uncaught MethodArgumentNotValidException",
         kv("parameter", ex.getParameter().getParameterName()),
-        kv("exception", ex));
+        ex);
     CTPException ourException =
         new CTPException(CTPException.Fault.VALIDATION_FAILED, INVALID_JSON);
     return new ResponseEntity<>(ourException, HttpStatus.BAD_REQUEST);

--- a/src/main/java/libs/common/retry/CTPUnknownHostRetryPolicy.java
+++ b/src/main/java/libs/common/retry/CTPUnknownHostRetryPolicy.java
@@ -1,11 +1,13 @@
 package libs.common.retry;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.google.common.base.Joiner;
 import java.util.Collections;
 import java.util.List;
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryPolicy;
 import org.springframework.retry.context.RetryContextSupport;
@@ -125,8 +127,7 @@ public class CTPUnknownHostRetryPolicy implements RetryPolicy {
         }
       }
     } catch (ClassNotFoundException e) {
-      log.with("class_names", Joiner.on(",").join(retryableExceptions))
-          .error("Invalid classname", e);
+      log.error("Invalid classname", kv("class_names", Joiner.on(",").join(retryableExceptions)));
     }
     return false;
   }
@@ -147,8 +148,7 @@ public class CTPUnknownHostRetryPolicy implements RetryPolicy {
         }
       }
     } catch (ClassNotFoundException e) {
-      log.with("class_names", Joiner.on(",").join(retryableExceptions))
-          .error("Invalid classname", e);
+      log.error("Invalid classname", kv("class_names", Joiner.on(",").join(retryableExceptions)));
     }
 
     return false;

--- a/src/main/java/libs/common/state/BasicStateTransitionManager.java
+++ b/src/main/java/libs/common/state/BasicStateTransitionManager.java
@@ -1,13 +1,15 @@
 package libs.common.state;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import libs.common.error.CTPException;
 import lombok.Data;
 import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Simple impl of StateTransitionManager
@@ -42,14 +44,15 @@ public class BasicStateTransitionManager<S, E> implements StateTransitionManager
       destinationState = outputMap.get(event);
     }
     if (destinationState == null) {
-      log.with("from", sourceState).with("event", event).warn("No valid transition");
+      log.warn("No valid transition", kv("from", sourceState), kv("event", event));
       throw new CTPException(
           CTPException.Fault.BAD_REQUEST, String.format(TRANSITION_ERROR_MSG, sourceState, event));
     } else {
-      log.with("from", sourceState)
-          .with("to", destinationState)
-          .with("event", event)
-          .info("Transitioning state");
+      log.warn(
+          "Transitioning state",
+          kv("from", sourceState),
+          kv("to", destinationState),
+          kv("event", event));
     }
     return destinationState;
   }

--- a/src/main/java/libs/common/time/DateTimeUtil.java
+++ b/src/main/java/libs/common/time/DateTimeUtil.java
@@ -1,7 +1,5 @@
 package libs.common.time;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -11,6 +9,8 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Centralized DateTime handling for CTP */
 @CoverageIgnore

--- a/src/main/java/libs/common/time/DateTimeUtil.java
+++ b/src/main/java/libs/common/time/DateTimeUtil.java
@@ -1,7 +1,7 @@
 package libs.common.time;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -11,6 +11,8 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Centralized DateTime handling for CTP */
 @CoverageIgnore
@@ -78,7 +80,7 @@ public class DateTimeUtil {
       gregorianCalendar.setTime(date);
       result = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
     } catch (ParseException e) {
-      log.error("Failed to parse date", e);
+      log.error("Failed to parse date", kv("exception", e));
       result = DateTimeUtil.giveMeCalendarForNow();
     }
 

--- a/src/main/java/libs/common/time/DateTimeUtil.java
+++ b/src/main/java/libs/common/time/DateTimeUtil.java
@@ -1,6 +1,5 @@
 package libs.common.time;
 
-import static net.logstash.logback.argument.StructuredArguments.kv;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -80,7 +79,7 @@ public class DateTimeUtil {
       gregorianCalendar.setTime(date);
       result = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
     } catch (ParseException e) {
-      log.error("Failed to parse date", kv("exception", e));
+      log.error("Failed to parse date", e);
       result = DateTimeUtil.giveMeCalendarForNow();
     }
 

--- a/src/main/java/libs/common/time/DateTimeUtil.java
+++ b/src/main/java/libs/common/time/DateTimeUtil.java
@@ -1,6 +1,7 @@
 package libs.common.time;
 
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -10,8 +11,6 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import net.sourceforge.cobertura.CoverageIgnore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Centralized DateTime handling for CTP */
 @CoverageIgnore

--- a/src/main/java/libs/common/util/AggregatedDateFormat.java
+++ b/src/main/java/libs/common/util/AggregatedDateFormat.java
@@ -1,12 +1,14 @@
 package libs.common.util;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.text.DateFormat;
 import java.text.FieldPosition;
 import java.text.ParsePosition;
 import java.util.Arrays;
 import java.util.Date;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is designed to provide more flexible parsing of dates than the standard DateFormats.
@@ -29,7 +31,7 @@ public class AggregatedDateFormat extends DateFormat {
   @Override
   public StringBuffer format(
       final Date date, final StringBuffer toAppendTo, final FieldPosition fieldPosition) {
-    log.with("date", date).trace("Formatting date to string");
+    log.trace("Formatting date to string", kv("date", date));
     return outputFormat.format(date, toAppendTo, fieldPosition);
   }
 
@@ -49,7 +51,7 @@ public class AggregatedDateFormat extends DateFormat {
 
   @Override
   public Date parse(final String source, final ParsePosition pos) {
-    log.with("string", source).trace("Parsing string to date");
+    log.trace("Parsing string to date", kv("string", source));
     return Arrays.stream(inputFormats).map(d -> d.parse(source, pos)).findFirst().orElse(null);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.ctp.response.sample;
 
-import com.godaddy.logging.LoggingConfigs;
-import javax.annotation.PostConstruct;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
@@ -58,13 +56,6 @@ public class SampleSvcApplication {
    */
   public static void main(final String[] args) {
     SpringApplication.run(SampleSvcApplication.class, args);
-  }
-
-  @PostConstruct
-  public void initJsonLogging() {
-    if (appConfig.getLogging().isUseJson()) {
-      LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
-    }
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -126,8 +126,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
           try {
             return Optional.of(this.sampleService.ingest(newSummary, file, type));
           } catch (Exception e) {
-            log.error(
-                "Failed to ingest sample", kv("sample_id", newSummary.getId()), kv("exception", e));
+            log.error("Failed to ingest sample", kv("sample_id", newSummary.getId()), e);
             return this.sampleService.failSampleSummary(newSummary, e);
           }
         };

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.sample.endpoint;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -17,6 +17,8 @@ import libs.common.time.DateTimeUtil;
 import libs.sample.validation.BusinessSampleUnit;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
 import ma.glasnost.orika.MapperFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
@@ -77,8 +79,9 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
               collectionExerciseJobCreationRequestDTO,
       BindingResult bindingResult)
       throws CTPException, InvalidRequestException {
-    log.with("collection_exercise_job_creation_request", collectionExerciseJobCreationRequestDTO)
-        .debug("Entering createCollectionExerciseJob ");
+    log.debug(
+        "Entering createCollectionExerciseJob ",
+        kv("collection_exercise_job_creation_request", collectionExerciseJobCreationRequestDTO));
     if (bindingResult.hasErrors()) {
       throw new InvalidRequestException("Binding errors for create action: ", bindingResult);
     }
@@ -123,7 +126,8 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
           try {
             return Optional.of(this.sampleService.ingest(newSummary, file, type));
           } catch (Exception e) {
-            log.with("sample_id", newSummary.getId()).error("Failed to ingest sample", e);
+            log.error(
+                "Failed to ingest sample", kv("sample_id", newSummary.getId()), kv("exception", e));
             return this.sampleService.failSampleSummary(newSummary, e);
           }
         };
@@ -140,7 +144,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   public ResponseEntity<SampleSummary> uploadSampleFile(
       @PathVariable("type") final String type, @RequestParam("file") MultipartFile file)
       throws CTPException {
-    log.with("sample_type", type).debug("Entering Sample file upload");
+    log.debug("Entering Sample file upload", kv("sample_type", type));
     if (!Arrays.asList("B", "CENSUS", "SOCIAL").contains(type.toUpperCase())) {
       return ResponseEntity.badRequest().build();
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterBusiness.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -23,6 +23,8 @@ import liquibase.util.StringUtils;
 import liquibase.util.csv.opencsv.CSVReader;
 import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -172,8 +174,9 @@ public class CsvIngesterBusiness extends CsvToBean<BusinessSampleUnit> {
     synchronized (unitRefs) {
       // If a unit ref is already registered
       if (unitRefs.contains(businessSampleUnit.getSampleUnitRef())) {
-        log.with("sample_unit_ref", businessSampleUnit.getSampleUnitRef())
-            .warn("sample unit ref is duplicated in the file.");
+        log.warn(
+            "sample unit ref is duplicated in the file.",
+            kv("sample_unit_ref", businessSampleUnit.getSampleUnitRef()));
         throw new CTPException(
             CTPException.Fault.VALIDATION_FAILED,
             String.format(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterCensus.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,6 +16,8 @@ import libs.sample.validation.CensusSampleUnit;
 import liquibase.util.csv.opencsv.CSVReader;
 import liquibase.util.csv.opencsv.bean.ColumnPositionMappingStrategy;
 import liquibase.util.csv.opencsv.bean.CsvToBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -116,9 +118,10 @@ public class CsvIngesterCensus extends CsvToBean<CensusSampleUnit> {
 
       Optional<String> namesOfInvalidColumns = validateLine(censusSampleUnit);
       if (namesOfInvalidColumns.isPresent()) {
-        log.with("line", Arrays.toString(nextLine))
-            .with("invalid_columns", namesOfInvalidColumns.get())
-            .error("Problem parsing line, entire ingest aborted");
+        log.error(
+            "Problem parsing line, entire ingest aborted",
+            kv("line", Arrays.toString(nextLine)),
+            kv("invalid_columns", namesOfInvalidColumns.get()));
         throw new CTPException(
             CTPException.Fault.VALIDATION_FAILED,
             String.format(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/ingest/CsvIngesterSocial.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.ctp.response.sample.ingest;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import com.google.common.collect.Sets;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -16,6 +14,8 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/EventPublisher.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,7 +18,7 @@ public class EventPublisher {
   private RabbitTemplate rabbitTemplate;
 
   public void publishEvent(String event) {
-    log.with("event", event).debug("Publish Event");
+    log.debug("Publish Event", kv("event", event));
     rabbitTemplate.convertAndSend(event);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyPublisher.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,7 +19,7 @@ public class PartyPublisher {
   private RabbitTemplate rabbitTemplate;
 
   public void publish(PartyCreationRequestDTO party) {
-    log.with("party", party).debug("send to queue to be sent to partySvc");
+    log.debug("send to queue to be sent to partySvc", kv("party", party));
     rabbitTemplate.convertAndSend(party);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyReceiver.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/PartyReceiver.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -16,7 +18,7 @@ public class PartyReceiver {
 
   @ServiceActivator(inputChannel = "partyTransformed", adviceChain = "partyRetryAdvice")
   public void acceptParty(PartyCreationRequestDTO party) throws Exception {
-    log.with("party", party).debug("acceptParty");
+    log.debug("acceptParty", kv("party", party));
     sampleService.sendToPartyService(party);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleOutboundPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleOutboundPublisher.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.ctp.response.sample.message;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import libs.common.error.CTPException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,9 +38,8 @@ public class SampleOutboundPublisher {
   private void sendMessage(String routingKey, SampleSummary sampleSummary) throws CTPException {
     try {
       String message = this.objectMapper.writeValueAsString(sampleSummary);
-      log.with("routing_key", routingKey)
-          .with("message", message)
-          .debug("Sending message to routing key");
+      log.debug(
+          "Sending message to routing key", kv("routing_key", routingKey), kv("message", message));
       rabbitTemplate.convertAndSend(routingKey, message);
     } catch (JsonProcessingException e) {
       throw new CTPException(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleUnitPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleUnitPublisher.java
@@ -1,8 +1,10 @@
 package uk.gov.ons.ctp.response.sample.message;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import net.sourceforge.cobertura.CoverageIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,7 +27,7 @@ public class SampleUnitPublisher {
    * @param sampleUnit to be sent
    */
   public void send(SampleUnit sampleUnit) {
-    log.with("sample_unit", sampleUnit).debug("send to queue sampleDelivery");
+    log.debug("send to queue sampleDelivery", kv("sample_unit", sampleUnit));
     rabbitTemplate.convertAndSend(sampleUnit);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -98,7 +98,8 @@ public class SampleUnitDistributor {
                 log.error(
                     "Failed to send a sample unit to queue and update state",
                     kv("sample_unit_id", mappedSampleUnit.getId()),
-                    kv("exception", e));
+                    "exception",
+                    e);
               }
             });
       }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -1,13 +1,15 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import libs.common.error.CTPException;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -93,8 +95,10 @@ public class SampleUnitDistributor {
                 sampleUnitSender.sendSampleUnit(mappedSampleUnit);
               } catch (CTPException e) {
                 hasErrors = true;
-                log.with("sample_unit_id", mappedSampleUnit.getId())
-                    .error("Failed to send a sample unit to queue and update state", e);
+                log.error(
+                    "Failed to send a sample unit to queue and update state",
+                    kv("sample_unit_id", mappedSampleUnit.getId()),
+                    kv("exception", e));
               }
             });
       }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSender.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSender.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ctp.response.sample.scheduled.distribution;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import java.util.UUID;
 import libs.common.error.CTPException;
 import libs.common.state.StateTransitionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/CollectionExerciseJobService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/CollectionExerciseJobService.java
@@ -1,10 +1,12 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.UUID;
 import libs.common.error.CTPException;
 import libs.common.error.CTPException.Fault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
@@ -23,8 +25,9 @@ public class CollectionExerciseJobService {
     if (collectionExerciseJobRepository.findByCollectionExerciseId(collectionExerciseId) == null) {
       collectionExerciseJobRepository.saveAndFlush(collectionExerciseJob);
     } else {
-      log.with("collection_exercise_id", collectionExerciseId)
-          .debug("CollectionExerciseId already exists in the collectionexercisejob table");
+      log.debug(
+          "CollectionExerciseId already exists in the collectionexercisejob table",
+          kv("collection_exercise_id", collectionExerciseId));
       throw new CTPException(
           Fault.BAD_REQUEST,
           "CollectionExerciseId %s already exists in the collectionexercisejob table",

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/PartySvcClientService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/PartySvcClientService.java
@@ -1,11 +1,13 @@
 package uk.gov.ons.ctp.response.sample.service;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import libs.common.rest.RestUtility;
 import libs.party.representation.PartyDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
@@ -61,7 +63,7 @@ public class PartySvcClientService {
         log.error("Unable to read party response", e);
       }
     }
-    log.with("party", party).debug("Successfully retrieved party");
+    log.debug("Successfully retrieved party", kv("party", party));
     eventPublisher.publishEvent("Sample PERSISTED");
     return party;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleReportService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleReportService.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleReportRepository;
@@ -21,6 +23,6 @@ public class SampleReportService {
     log.debug("Entering createReport...");
 
     boolean reportResult = sampleReportRepository.chasingReportStoredProcedure();
-    log.with("report_result", reportResult).debug("Just ran the chasing report and got result");
+    log.debug("Just ran the chasing report and got result", kv("report_result", reportResult));
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +13,8 @@ import libs.common.state.StateTransitionManager;
 import libs.common.time.DateTimeUtil;
 import libs.party.representation.PartyDTO;
 import libs.sample.validation.SampleUnitBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
@@ -250,8 +252,10 @@ public class SampleService {
 
       return Optional.of(persisted);
     } catch (CTPException e) {
-      log.with("sample_summary", sampleSummary.getId())
-          .error("Failed to put sample summary into FAILED state", e);
+      log.error(
+          "Failed to put sample summary into FAILED state",
+          kv("sample_summary", sampleSummary.getId()),
+          kv("exception", e));
 
       return Optional.empty();
     } catch (RuntimeException e) {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -255,7 +255,7 @@ public class SampleService {
       log.error(
           "Failed to put sample summary into FAILED state",
           kv("sample_summary", sampleSummary.getId()),
-          kv("exception", e));
+          e);
 
       return Optional.empty();
     } catch (RuntimeException e) {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,24 +15,15 @@
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
         <timestamp>
-          <timeZone>UTC</timeZone>
+          <timeZone>Europe/London</timeZone>
           <pattern>${ISO8601_DATE_FORMAT}</pattern>
           <fieldName>created</fieldName>
         </timestamp>
-        <Pattern>
-          <Pattern>
-            {
-            "trace" : "%X{X-B3-TraceId:-}",
-            "span" : "%X{X-B3-SpanId:-}",
-            "parent" : "%X{X-B3-ParentSpanId:-}"
-            }
-          </Pattern>
-        </Pattern>
         <globalCustomFields>
-          <customFields>{"service":"samplesvc"}</customFields>
+          <customFields>{"service":"sample"}</customFields>
         </globalCustomFields>
         <message>
-          <fieldName>event</fieldName>
+          <fieldName>message</fieldName>
         </message>
         <loggerName/>
         <threadName/>

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointIT.java
@@ -5,8 +5,6 @@ import static org.assertj.core.data.MapEntry.entry;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
@@ -22,6 +20,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Godaddy logging is abandonware. use slf4j with logback backend.

where godaddy uses `log.with("key", value).info("message")`, logback uses `log.info("message", kv.("key", value))`
Very similar and allows for outputting objects in JSON format.