### PR TITLE
add proxy request/limits

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.1
+appVersion: 11.1.2

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
               secretKeyRef:
                 name: db-config
                 key: db-port
+          resources:
+            {{- toYaml .Values.resources.proxy | nindent 12 }}
         {{- end }}
         - name: {{ .Chart.Name }}
           {{- if eq .Values.image.tag "latest"}}
@@ -192,4 +194,4 @@ spec:
           - name: SPRING_DATASOURCE_PASSWORD
             value: "$(DB_PASSWORD)"
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.application | nindent 12 }}

--- a/_infra/helm/sample/values.yaml
+++ b/_infra/helm/sample/values.yaml
@@ -26,12 +26,20 @@ service:
   port: 8080
 
 resources:
-  requests:
-    memory: "250Mi"
-    cpu: "50m"
-  limits:
-    cpu: "200m"
-    memory: "1500Mi"
+  application:
+    requests:
+      memory: "512Mi"
+      cpu: "400m"
+    limits:
+      memory: "1500Mi"
+      cpu: "1000m"
+  proxy:
+    requests:
+      memory: "25Mi"
+      cpu: "10m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"
 
 autoscaling: false
 scaleAt:


### PR DESCRIPTION
Add request/limit to the proxy container.
This is required for a HPA to detect the current request for a pod as a sum of all containers.