### PR TITLE
Stop duplicate samples being created within a single sample summary

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.8
+appVersion: 11.1.9

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
@@ -48,6 +48,8 @@ public interface SampleUnitRepository extends JpaRepository<SampleUnit, Integer>
    */
   SampleUnit findBySampleUnitRef(String sampleUnitRef);
 
+  SampleUnit findBySampleUnitRefAndSampleSummaryFK(String sampleUnitRef, Integer sampleSummary);
+
   /**
    * Find how many SampleUnits from a given SampleSummary have been POSTed to Party and are now
    * 'PERSISTED'

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -17,6 +17,7 @@ import ma.glasnost.orika.MapperFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
@@ -220,7 +221,11 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
               URI.create(String.format("/samples/%s", sampleUnit.getSampleUnitPK())))
           .contentType(MediaType.APPLICATION_JSON)
           .body(sampleUnitDTO);
-    } catch (UnknownSampleSummaryException e) {
+    } catch (IllegalStateException e) {
+      log.error("duplicate sample", kv("sampleSummaryId", sampleSummaryId), e);
+      return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+    catch (UnknownSampleSummaryException e) {
       log.error("unknown sample summary id", kv("sampleSummaryId", sampleSummaryId), e);
       return ResponseEntity.badRequest().build();
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -93,7 +93,16 @@ public class SampleService {
     if (sampleSummary != null) {
       // the csv ingester does this so it's needed here
       samplingUnit.setSampleUnitType("B");
-      return createAndSaveSampleUnit(sampleSummary, sampleUnitState, samplingUnit);
+
+      /**
+       * a sample unit should be unique inside a sample summary, so check if we already have it.
+       */
+      SampleUnit sampleUnit = sampleUnitRepository.findBySampleUnitRefAndSampleSummaryFK(samplingUnit.getSampleUnitRef(), sampleSummary.getSampleSummaryPK());
+      if (sampleUnit == null) {
+        return createAndSaveSampleUnit(sampleSummary, sampleUnitState, samplingUnit);
+      } else {
+        throw new IllegalStateException("sample unit already exists");
+      }
     } else {
       throw new UnknownSampleSummaryException();
     }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -279,6 +279,24 @@ public class SampleServiceTest {
     verify(sampleUnitRepository, times(1)).save(any(SampleUnit.class));
   }
 
+  @Test
+  public void createDuplicateSampleUnitThrowsIllegalStateException() throws UnknownSampleSummaryException {
+    SampleSummary newSummary = createSampleSummary(5, 2);
+    when(sampleSummaryRepository.findById(any())).thenReturn(newSummary);
+    BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
+    SampleUnit sampleUnit = sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
+    when(sampleUnitRepository.findBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(sampleUnit);
+
+    try {
+      sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
+      fail("second attempt to create the same sample should fail");
+    } catch (IllegalStateException e) {
+      //expected exception
+    }
+    // confirm it was only saved once
+    verify(sampleUnitRepository, times(1)).save(any(SampleUnit.class));
+  }
+
   @Test(expected = UnknownSampleSummaryException.class)
   public void createSampleUnitWithUnknownSampleSummary() throws UnknownSampleSummaryException {
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Stops a sample unit being created twice within a sample summary

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
