### PR TITLE
Use exist rather than getting the sample unit

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.9
+appVersion: 11.1.10

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
@@ -48,7 +48,7 @@ public interface SampleUnitRepository extends JpaRepository<SampleUnit, Integer>
    */
   SampleUnit findBySampleUnitRef(String sampleUnitRef);
 
-  SampleUnit findBySampleUnitRefAndSampleSummaryFK(String sampleUnitRef, Integer sampleSummary);
+  boolean existsBySampleUnitRefAndSampleSummaryFK(String sampleUnitRef, Integer sampleSummary);
 
   /**
    * Find how many SampleUnits from a given SampleSummary have been POSTed to Party and are now

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -97,8 +97,8 @@ public class SampleService {
       /**
        * a sample unit should be unique inside a sample summary, so check if we already have it.
        */
-      SampleUnit sampleUnit = sampleUnitRepository.findBySampleUnitRefAndSampleSummaryFK(samplingUnit.getSampleUnitRef(), sampleSummary.getSampleSummaryPK());
-      if (sampleUnit == null) {
+      boolean exists = sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(samplingUnit.getSampleUnitRef(), sampleSummary.getSampleSummaryPK());
+      if (!exists) {
         return createAndSaveSampleUnit(sampleSummary, sampleUnitState, samplingUnit);
       } else {
         throw new IllegalStateException("sample unit already exists");

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -285,7 +285,7 @@ public class SampleServiceTest {
     when(sampleSummaryRepository.findById(any())).thenReturn(newSummary);
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     SampleUnit sampleUnit = sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
-    when(sampleUnitRepository.findBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(sampleUnit);
+    when(sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(true);
 
     try {
       sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changing to exist because it is possible under heavy load for the sample unit to be created twice and then the query to get one fails.

This should hopefully stop the majority of duplicates being created in the system.


# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
