### PR TITLE
JPA fixes - use Optional for findById and correct call to activate sample summary

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.2.3
+appVersion: 11.2.4

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.sample.domain.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,5 +16,5 @@ public interface SampleSummaryRepository extends JpaRepository<SampleSummary, In
    * @param id the UUID of the sampleSummary
    * @return SampleSummary object
    */
-  SampleSummary findById(UUID id);
+  Optional<SampleSummary> findById(UUID id);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -8,7 +8,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 
 /** JPA Data Repository needed to persist Survey SampleSummarys */
 @Repository
-public interface SampleSummaryRepository extends JpaRepository<SampleSummary, Integer> {
+public interface SampleSummaryRepository extends JpaRepository<SampleSummary, UUID> {
 
   /**
    * Find SampleSummary by UUID

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -16,5 +16,5 @@ public interface SampleSummaryRepository extends JpaRepository<SampleSummary, In
    * @param id the UUID of the sampleSummary
    * @return SampleSummary object
    */
-  Optional<SampleSummary> findSampleSummaryById(UUID id);
+  Optional<SampleSummary> findById(UUID id);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -16,5 +16,5 @@ public interface SampleSummaryRepository extends JpaRepository<SampleSummary, In
    * @param id the UUID of the sampleSummary
    * @return SampleSummary object
    */
-  Optional<SampleSummary> findById(UUID id);
+  Optional<SampleSummary> findSampleSummaryById(UUID id);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -8,7 +8,7 @@ import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 
 /** JPA Data Repository needed to persist Survey SampleSummarys */
 @Repository
-public interface SampleSummaryRepository extends JpaRepository<SampleSummary, UUID> {
+public interface SampleSummaryRepository extends JpaRepository<SampleSummary, Integer> {
 
   /**
    * Find SampleSummary by UUID

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -17,4 +17,6 @@ public interface SampleSummaryRepository extends JpaRepository<SampleSummary, In
    * @return SampleSummary object
    */
   Optional<SampleSummary> findById(UUID id);
+
+  Optional<SampleSummary> findBySampleSummaryPK(Integer sampleSummaryPK);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
@@ -11,7 +11,7 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 /** JPA Data Repository needed to persist Survey Sample Units */
 @Repository
-public interface SampleUnitRepository extends JpaRepository<SampleUnit, Integer> {
+public interface SampleUnitRepository extends JpaRepository<SampleUnit, UUID> {
 
   /**
    * Find SampleUnit entity by samplesummaryfk

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
@@ -11,7 +11,7 @@ import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 /** JPA Data Repository needed to persist Survey Sample Units */
 @Repository
-public interface SampleUnitRepository extends JpaRepository<SampleUnit, UUID> {
+public interface SampleUnitRepository extends JpaRepository<SampleUnit, Integer> {
 
   /**
    * Find SampleUnit entity by samplesummaryfk

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleUnitRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.sample.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -43,5 +44,5 @@ public interface SampleUnitRepository extends JpaRepository<SampleUnit, Integer>
    */
   int countBySampleSummaryFKAndState(Integer sampleSummaryFK, SampleUnitDTO.SampleUnitState state);
 
-  SampleUnit findById(UUID id);
+  Optional<SampleUnit> findById(UUID id);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -235,7 +235,9 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   public ResponseEntity<SampleSummaryDTO> createSampleSummary(
       final @RequestBody SampleSummaryDTO requestSummary) {
     SampleSummary sampleSummary = sampleService.createAndSaveSampleSummary(requestSummary);
-
+    if (sampleSummary != null) {
+      log.debug("sample summary created", kv("sampleSummaryId", sampleSummary.getId()));
+    }
     SampleSummaryDTO sampleSummaryDTO = mapperFacade.map(sampleSummary, SampleSummaryDTO.class);
 
     return ResponseEntity.created(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -52,7 +52,7 @@ public class SampleUnitDistributor {
   private void processJob(CollectionExerciseJob job) throws SampleDistributionException {
     UUID sampleSummaryId = job.getSampleSummaryId();
     try {
-      List<SampleUnit> invalidSamples = Optional.of(sampleSummaryRepository.findSampleSummaryById(sampleSummaryId)).orElseThrow()
+      List<SampleUnit> invalidSamples = Optional.of(sampleSummaryRepository.findById(sampleSummaryId)).orElseThrow()
               .filter(sampleSummary -> sampleSummary.getState() == SampleState.ACTIVE)
               .map(sampleSummary -> sampleUnitRepository.findBySampleSummaryFKAndState(
                       sampleSummary.getSampleSummaryPK(), SampleUnitState.PERSISTED))

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -52,7 +52,7 @@ public class SampleUnitDistributor {
   private void processJob(CollectionExerciseJob job) throws SampleDistributionException {
     UUID sampleSummaryId = job.getSampleSummaryId();
     try {
-      List<SampleUnit> invalidSamples = Optional.of(sampleSummaryRepository.findById(sampleSummaryId)).orElseThrow()
+      List<SampleUnit> invalidSamples = Optional.of(sampleSummaryRepository.findSampleSummaryById(sampleSummaryId)).orElseThrow()
               .filter(sampleSummary -> sampleSummary.getState() == SampleState.ACTIVE)
               .map(sampleSummary -> sampleUnitRepository.findBySampleSummaryFKAndState(
                       sampleSummary.getSampleSummaryPK(), SampleUnitState.PERSISTED))

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -60,7 +60,7 @@ public class SampleService {
   }
 
   public SampleSummary findSampleSummary(UUID id) {
-    return sampleSummaryRepository.findSampleSummaryById(id).orElse(null);
+    return sampleSummaryRepository.findById(id).orElse(null);
   }
 
   @Transactional(propagation = Propagation.REQUIRED)
@@ -83,7 +83,7 @@ public class SampleService {
       UUID sampleSummaryId, BusinessSampleUnit samplingUnit, SampleUnitState sampleUnitState)
       throws UnknownSampleSummaryException {
 
-    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
     if (sampleSummary != null) {
       // the csv ingester does this so it's needed here
       samplingUnit.setSampleUnitType("B");
@@ -175,7 +175,7 @@ public class SampleService {
   public SampleSummary activateSampleSummaryState(UUID sampleSummaryID) throws CTPException {
     log.debug("attempting to find sample summary", kv("sampleSummaryId", sampleSummaryID));
     try {
-      SampleSummary targetSampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryID).orElseThrow();
+      SampleSummary targetSampleSummary = sampleSummaryRepository.findById(sampleSummaryID).orElseThrow();
       SampleState newState =
               sampleSvcStateTransitionManager.transition(
                       targetSampleSummary.getState(), SampleEvent.ACTIVATED);
@@ -235,7 +235,7 @@ public class SampleService {
     // Integer sampleUnitsTotal =
     // initialiseSampleUnitsForCollectionExcerciseCollection(job.getSampleSummaryId());
     Integer sampleUnitsTotal = 0;
-    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(job.getSampleSummaryId()).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(job.getSampleSummaryId()).orElse(null);
     if (sampleSummary != null && sampleSummary.getTotalSampleUnits() != 0) {
       sampleUnitsTotal = sampleSummary.getTotalSampleUnits();
       collectionExerciseJobService.storeCollectionExerciseJob(job);
@@ -244,7 +244,7 @@ public class SampleService {
   }
 
   public int getSampleSummaryUnitCount(UUID sampleSummaryId) {
-    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
     if (sampleSummary == null) {
       throw new IllegalArgumentException(
           String.format("Sample summary %s cannot be found", sampleSummaryId));
@@ -299,7 +299,7 @@ public class SampleService {
 
   public List<SampleUnit> findSampleUnitsBySampleSummary(UUID sampleSummaryId) {
     try {
-      SampleSummary ss = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElseThrow();
+      SampleSummary ss = sampleSummaryRepository.findById(sampleSummaryId).orElseThrow();
       return sampleUnitRepository.findBySampleSummaryFK(ss.getSampleSummaryPK());
     } catch (NoSuchElementException e) {
         log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -133,12 +133,11 @@ public class SampleService {
   @Transactional(propagation = Propagation.REQUIRED, readOnly = false)
   public SampleSummary createAndSaveSampleSummary(SampleSummaryDTO summaryDTO) {
     SampleSummary sampleSummary = new SampleSummary();
-
     sampleSummary.setState(SampleState.INIT);
     sampleSummary.setId(UUID.randomUUID());
     sampleSummary.setTotalSampleUnits(summaryDTO.getTotalSampleUnits());
     sampleSummary.setExpectedCollectionInstruments(summaryDTO.getExpectedCollectionInstruments());
-
+    log.debug("about to save sample summary");
     return sampleSummaryRepository.save(sampleSummary);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -60,7 +60,7 @@ public class SampleService {
   }
 
   public SampleSummary findSampleSummary(UUID id) {
-    return sampleSummaryRepository.findById(id).orElse(null);
+    return sampleSummaryRepository.findSampleSummaryById(id).orElse(null);
   }
 
   @Transactional(propagation = Propagation.REQUIRED)
@@ -83,7 +83,7 @@ public class SampleService {
       UUID sampleSummaryId, BusinessSampleUnit samplingUnit, SampleUnitState sampleUnitState)
       throws UnknownSampleSummaryException {
 
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElse(null);
     if (sampleSummary != null) {
       // the csv ingester does this so it's needed here
       samplingUnit.setSampleUnitType("B");
@@ -175,7 +175,7 @@ public class SampleService {
   public SampleSummary activateSampleSummaryState(UUID sampleSummaryID) throws CTPException {
     log.debug("attempting to find sample summary", kv("sampleSummaryId", sampleSummaryID));
     try {
-      SampleSummary targetSampleSummary = sampleSummaryRepository.findById(sampleSummaryID).orElseThrow();
+      SampleSummary targetSampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryID).orElseThrow();
       SampleState newState =
               sampleSvcStateTransitionManager.transition(
                       targetSampleSummary.getState(), SampleEvent.ACTIVATED);
@@ -235,7 +235,7 @@ public class SampleService {
     // Integer sampleUnitsTotal =
     // initialiseSampleUnitsForCollectionExcerciseCollection(job.getSampleSummaryId());
     Integer sampleUnitsTotal = 0;
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(job.getSampleSummaryId()).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(job.getSampleSummaryId()).orElse(null);
     if (sampleSummary != null && sampleSummary.getTotalSampleUnits() != 0) {
       sampleUnitsTotal = sampleSummary.getTotalSampleUnits();
       collectionExerciseJobService.storeCollectionExerciseJob(job);
@@ -244,7 +244,7 @@ public class SampleService {
   }
 
   public int getSampleSummaryUnitCount(UUID sampleSummaryId) {
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
+    SampleSummary sampleSummary = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElse(null);
     if (sampleSummary == null) {
       throw new IllegalArgumentException(
           String.format("Sample summary %s cannot be found", sampleSummaryId));
@@ -299,7 +299,7 @@ public class SampleService {
 
   public List<SampleUnit> findSampleUnitsBySampleSummary(UUID sampleSummaryId) {
     try {
-      SampleSummary ss = sampleSummaryRepository.findById(sampleSummaryId).orElseThrow();
+      SampleSummary ss = sampleSummaryRepository.findSampleSummaryById(sampleSummaryId).orElseThrow();
       return sampleUnitRepository.findBySampleSummaryFK(ss.getSampleSummaryPK());
     } catch (NoSuchElementException e) {
         log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -2,11 +2,8 @@ package uk.gov.ons.ctp.response.sample.service;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+
 import libs.common.error.CTPException;
 import libs.common.state.StateTransitionManager;
 import libs.common.time.DateTimeUtil;
@@ -63,7 +60,7 @@ public class SampleService {
   }
 
   public SampleSummary findSampleSummary(UUID id) {
-    return sampleSummaryRepository.findById(id);
+    return sampleSummaryRepository.findById(id).orElse(null);
   }
 
   @Transactional(propagation = Propagation.REQUIRED)
@@ -86,7 +83,7 @@ public class SampleService {
       UUID sampleSummaryId, BusinessSampleUnit samplingUnit, SampleUnitState sampleUnitState)
       throws UnknownSampleSummaryException {
 
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId);
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
     if (sampleSummary != null) {
       // the csv ingester does this so it's needed here
       samplingUnit.setSampleUnitType("B");
@@ -177,26 +174,37 @@ public class SampleService {
    * @throws CTPException if transition errors
    */
   public SampleSummary activateSampleSummaryState(UUID sampleSummaryID) throws CTPException {
-    SampleSummary targetSampleSummary = sampleSummaryRepository.findById(sampleSummaryID);
-    SampleState newState =
-        sampleSvcStateTransitionManager.transition(
-            targetSampleSummary.getState(), SampleEvent.ACTIVATED);
-    targetSampleSummary.setState(newState);
-    targetSampleSummary.setIngestDateTime(DateTimeUtil.nowUTC());
-    sampleSummaryRepository.saveAndFlush(targetSampleSummary);
-
-    return targetSampleSummary;
+    log.debug("attempting to find sample summary", kv("sampleSummaryId", sampleSummaryID));
+    try {
+      SampleSummary targetSampleSummary = sampleSummaryRepository.findById(sampleSummaryID).orElseThrow();
+      SampleState newState =
+              sampleSvcStateTransitionManager.transition(
+                      targetSampleSummary.getState(), SampleEvent.ACTIVATED);
+      targetSampleSummary.setState(newState);
+      targetSampleSummary.setIngestDateTime(DateTimeUtil.nowUTC());
+      sampleSummaryRepository.saveAndFlush(targetSampleSummary);
+      return targetSampleSummary;
+    } catch (NoSuchElementException e) {
+      log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryID));
+      throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND);
+    }
   }
 
   public PartyDTO sendToPartyService(PartyCreationRequestDTO partyCreationRequest)
       throws Exception {
     PartyDTO returnedParty = partySvcClient.postParty(partyCreationRequest);
-    SampleUnit sampleUnit =
-        sampleUnitRepository.findById(
-            UUID.fromString(partyCreationRequest.getAttributes().getSampleUnitId()));
-    changeSampleUnitState(sampleUnit);
-    sampleSummaryStateCheck(sampleUnit);
-    return returnedParty;
+    String sampleUnitId = partyCreationRequest.getAttributes().getSampleUnitId();
+    try {
+      SampleUnit sampleUnit =
+              sampleUnitRepository.findById(
+                      UUID.fromString(sampleUnitId)).orElseThrow();
+      changeSampleUnitState(sampleUnit);
+      sampleSummaryStateCheck(sampleUnit);
+      return returnedParty;
+    } catch (NoSuchElementException e) {
+        log.error("unable to find sample ", kv("sampleUnitId", sampleUnitId));
+        throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND);
+    }
   }
 
   private void changeSampleUnitState(SampleUnit sampleUnit) throws CTPException {
@@ -228,7 +236,7 @@ public class SampleService {
     // Integer sampleUnitsTotal =
     // initialiseSampleUnitsForCollectionExcerciseCollection(job.getSampleSummaryId());
     Integer sampleUnitsTotal = 0;
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(job.getSampleSummaryId());
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(job.getSampleSummaryId()).orElse(null);
     if (sampleSummary != null && sampleSummary.getTotalSampleUnits() != 0) {
       sampleUnitsTotal = sampleSummary.getTotalSampleUnits();
       collectionExerciseJobService.storeCollectionExerciseJob(job);
@@ -237,8 +245,7 @@ public class SampleService {
   }
 
   public int getSampleSummaryUnitCount(UUID sampleSummaryId) {
-    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId);
-
+    SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
     if (sampleSummary == null) {
       throw new IllegalArgumentException(
           String.format("Sample summary %s cannot be found", sampleSummaryId));
@@ -287,16 +294,17 @@ public class SampleService {
   // TODO get this to get the attributes in a separate call then stitch the results into the value
   // returned by sampleUnitRepository.findById
   public SampleUnit findSampleUnit(UUID id) {
-    SampleUnit su = sampleUnitRepository.findById(id);
+    SampleUnit su = sampleUnitRepository.findById(id).orElse(null);
     return su;
   }
 
-  public SampleUnit findSampleUnitBySampleUnitId(UUID sampleUnitId) {
-    return sampleUnitRepository.findById(sampleUnitId);
-  }
-
   public List<SampleUnit> findSampleUnitsBySampleSummary(UUID sampleSummaryId) {
-    SampleSummary ss = sampleSummaryRepository.findById(sampleSummaryId);
-    return sampleUnitRepository.findBySampleSummaryFK(ss.getSampleSummaryPK());
+    try {
+      SampleSummary ss = sampleSummaryRepository.findById(sampleSummaryId).orElseThrow();
+      return sampleUnitRepository.findBySampleSummaryFK(ss.getSampleSummaryPK());
+    } catch (NoSuchElementException e) {
+        log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));
+        return new ArrayList<>();
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -168,14 +168,14 @@ public class SampleService {
   /**
    * Effect a state transition for the target SampleSummary if one is required
    *
-   * @param sampleSummaryID the sampleSummaryID to be updated
+   * @param sampleSummaryPK the sampleSummaryPK to be updated
    * @return SampleSummary the updated SampleSummary
    * @throws CTPException if transition errors
    */
-  public SampleSummary activateSampleSummaryState(UUID sampleSummaryID) throws CTPException {
-    log.debug("attempting to find sample summary", kv("sampleSummaryId", sampleSummaryID));
+  public SampleSummary activateSampleSummaryState(Integer sampleSummaryPK) throws CTPException {
+        log.debug("attempting to find sample summary", kv("sampleSummaryPK", sampleSummaryPK));
     try {
-      SampleSummary targetSampleSummary = sampleSummaryRepository.findById(sampleSummaryID).orElseThrow();
+      SampleSummary targetSampleSummary = sampleSummaryRepository.findBySampleSummaryPK(sampleSummaryPK).orElseThrow();
       SampleState newState =
               sampleSvcStateTransitionManager.transition(
                       targetSampleSummary.getState(), SampleEvent.ACTIVATED);
@@ -184,7 +184,7 @@ public class SampleService {
       sampleSummaryRepository.saveAndFlush(targetSampleSummary);
       return targetSampleSummary;
     } catch (NoSuchElementException e) {
-      log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryID));
+      log.error("unable to find sample summary", kv("sampleSummaryPK", sampleSummaryPK));
       throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND);
     }
   }
@@ -220,7 +220,7 @@ public class SampleService {
             sampleUnit.getSampleSummaryFK(), SampleUnitState.PERSISTED);
     int total = sampleUnitRepository.countBySampleSummaryFK(sampleUnit.getSampleSummaryFK());
     if (total == partied) {
-      activateSampleSummaryState(sampleUnit.getId());
+      activateSampleSummaryState(sampleUnit.getSampleSummaryFK());
     }
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -70,7 +71,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(sampleSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -110,7 +111,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(sampleSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -150,7 +151,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(sampleSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 
@@ -178,7 +179,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(sampleSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -71,7 +71,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -111,7 +111,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -151,7 +151,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 
@@ -179,7 +179,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributorTest.java
@@ -71,7 +71,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -111,7 +111,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
     when(sampleUnitRepository.findBySampleSummaryFKAndState(any(), any()))
         .thenReturn(Stream.of(sampleUnit));
     when(sampleUnitMapper.mapSampleUnit(any(), any())).thenReturn(mappedSampleUnit);
@@ -151,7 +151,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 
@@ -179,7 +179,7 @@ public class SampleUnitDistributorTest {
 
     when(collectionExerciseJobRepository.findByJobCompleteIsFalse())
         .thenReturn(Collections.singletonList(collectionExerciseJob));
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleSummary));
 
     sampleUnitDistributor.distribute();
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSenderTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitSenderTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.UUID;
 import libs.common.error.CTPException;
 import libs.common.state.StateTransitionManager;
@@ -41,7 +42,7 @@ public class SampleUnitSenderTest {
         new uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit();
     mappedSampleUnit.setId(UUID.randomUUID().toString());
 
-    when(sampleUnitRepository.findById(any(UUID.class))).thenReturn(sampleUnit);
+    when(sampleUnitRepository.findById(any(UUID.class))).thenReturn(Optional.of(sampleUnit));
     when(sampleUnitStateTransitionManager.transition(any(), any()))
         .thenReturn(SampleUnitState.DELIVERED);
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -134,7 +134,7 @@ public class SampleServiceTest {
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
-    when(sampleSummaryRepository.findSampleSummaryById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
+    when(sampleSummaryRepository.findById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
     when(sampleSvcStateTransitionManager.transition(SampleState.INIT, SampleEvent.ACTIVATED))
         .thenReturn(SampleState.ACTIVE);
 
@@ -191,7 +191,7 @@ public class SampleServiceTest {
   @Test
   public void testOneCollectionExerciseJobIsStoredWhenSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(1)).storeCollectionExerciseJob(any());
@@ -216,7 +216,7 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(0, 2);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
@@ -232,7 +232,7 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleSummaryIsFound() throws Exception {
     SampleSummary sampleSummary = null;
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.ofNullable(sampleSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(sampleSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
@@ -242,7 +242,7 @@ public class SampleServiceTest {
   @Test
   public void getSampleSummaryUnitCountHappyPath() {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     int actualResult = sampleService.getSampleSummaryUnitCount(newSummary.getId());
 
@@ -251,7 +251,7 @@ public class SampleServiceTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void getSampleSummaryUnitCountSampleSummaryNonExistent() {
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
 
     sampleService.getSampleSummaryUnitCount(UUID.randomUUID());
   }
@@ -260,7 +260,7 @@ public class SampleServiceTest {
   public void getSampleSummaryUnitCountSampleSummaryNullSize() {
     SampleSummary newSummary = createSampleSummary(5, 2);
     newSummary.setTotalSampleUnits(null);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     sampleService.getSampleSummaryUnitCount(newSummary.getId());
   }
@@ -268,7 +268,7 @@ public class SampleServiceTest {
   @Test
   public void createSampleUnit() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     verify(sampleUnitRepository, times(1)).save(any(SampleUnit.class));
@@ -277,7 +277,7 @@ public class SampleServiceTest {
   @Test
   public void createDuplicateSampleUnitThrowsIllegalStateException() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     SampleUnit sampleUnit = sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     when(sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(true);

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import libs.common.FixtureHelper;
 import libs.common.state.StateTransitionManager;
@@ -129,11 +130,11 @@ public class SampleServiceTest {
   public void postPartyDTOToPartyServiceAndUpdateStatesTest() throws Exception {
     when(partySvcClient.postParty(any())).thenReturn(partyDTO.get(0));
     when(sampleUnitRepository.findById(UUID.fromString(SAMPLEUNIT_ID)))
-        .thenReturn(sampleUnit.get(0));
+        .thenReturn(Optional.of(sampleUnit.get(0)));
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
-    when(sampleSummaryRepository.findById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(sampleSummaryList.get(0));
+    when(sampleSummaryRepository.findById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
     when(sampleSvcStateTransitionManager.transition(SampleState.INIT, SampleEvent.ACTIVATED))
         .thenReturn(SampleState.ACTIVE);
 
@@ -154,7 +155,7 @@ public class SampleServiceTest {
   public void sendToPartyServiceTestNotAllSampleUnitsPosted() throws Exception {
     when(partySvcClient.postParty(any())).thenReturn(partyDTO.get(0));
     when(sampleUnitRepository.findById(UUID.fromString(SAMPLEUNIT_ID)))
-        .thenReturn(sampleUnit.get(0));
+        .thenReturn(Optional.of(sampleUnit.get(0)));
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
@@ -190,7 +191,7 @@ public class SampleServiceTest {
   @Test
   public void testOneCollectionExerciseJobIsStoredWhenSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(1)).storeCollectionExerciseJob(any());
@@ -215,7 +216,7 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(0, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
@@ -231,17 +232,17 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleSummaryIsFound() throws Exception {
     SampleSummary sampleSummary = null;
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(sampleSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(sampleSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
-    assertThat(sampleUnitsTotal, is(0));
+    assertEquals(0, sampleUnitsTotal.intValue());
   }
 
   @Test
   public void getSampleSummaryUnitCountHappyPath() {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     int actualResult = sampleService.getSampleSummaryUnitCount(newSummary.getId());
 
@@ -250,7 +251,7 @@ public class SampleServiceTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void getSampleSummaryUnitCountSampleSummaryNonExistent() {
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(null);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
 
     sampleService.getSampleSummaryUnitCount(UUID.randomUUID());
   }
@@ -259,7 +260,7 @@ public class SampleServiceTest {
   public void getSampleSummaryUnitCountSampleSummaryNullSize() {
     SampleSummary newSummary = createSampleSummary(5, 2);
     newSummary.setTotalSampleUnits(null);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     sampleService.getSampleSummaryUnitCount(newSummary.getId());
   }
@@ -267,7 +268,7 @@ public class SampleServiceTest {
   @Test
   public void createSampleUnit() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     verify(sampleUnitRepository, times(1)).save(any(SampleUnit.class));
@@ -276,7 +277,7 @@ public class SampleServiceTest {
   @Test
   public void createDuplicateSampleUnitThrowsIllegalStateException() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(newSummary);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     SampleUnit sampleUnit = sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     when(sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(true);

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -134,7 +134,7 @@ public class SampleServiceTest {
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
-    when(sampleSummaryRepository.findById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
+    when(sampleSummaryRepository.findBySampleSummaryPK(1)).thenReturn(Optional.of(sampleSummaryList.get(0)));
     when(sampleSvcStateTransitionManager.transition(SampleState.INIT, SampleEvent.ACTIVATED))
         .thenReturn(SampleState.ACTIVE);
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -134,7 +134,7 @@ public class SampleServiceTest {
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
-    when(sampleSummaryRepository.findById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
+    when(sampleSummaryRepository.findSampleSummaryById(UUID.fromString(SAMPLEUNIT_ID))).thenReturn(Optional.of(sampleSummaryList.get(0)));
     when(sampleSvcStateTransitionManager.transition(SampleState.INIT, SampleEvent.ACTIVATED))
         .thenReturn(SampleState.ACTIVE);
 
@@ -191,7 +191,7 @@ public class SampleServiceTest {
   @Test
   public void testOneCollectionExerciseJobIsStoredWhenSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(1)).storeCollectionExerciseJob(any());
@@ -216,7 +216,7 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleUnitsAreFound() throws Exception {
     SampleSummary newSummary = createSampleSummary(0, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
@@ -232,7 +232,7 @@ public class SampleServiceTest {
   @Test
   public void testNoCollectionExerciseJobIsStoredWhenNoSampleSummaryIsFound() throws Exception {
     SampleSummary sampleSummary = null;
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(sampleSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.ofNullable(sampleSummary));
     Integer sampleUnitsTotal =
         sampleService.initialiseCollectionExerciseJob(collectionExerciseJobs.get(0));
     verify(collectionExerciseJobService, times(0)).storeCollectionExerciseJob(any());
@@ -242,7 +242,7 @@ public class SampleServiceTest {
   @Test
   public void getSampleSummaryUnitCountHappyPath() {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     int actualResult = sampleService.getSampleSummaryUnitCount(newSummary.getId());
 
@@ -251,7 +251,7 @@ public class SampleServiceTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void getSampleSummaryUnitCountSampleSummaryNonExistent() {
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
 
     sampleService.getSampleSummaryUnitCount(UUID.randomUUID());
   }
@@ -260,7 +260,7 @@ public class SampleServiceTest {
   public void getSampleSummaryUnitCountSampleSummaryNullSize() {
     SampleSummary newSummary = createSampleSummary(5, 2);
     newSummary.setTotalSampleUnits(null);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
 
     sampleService.getSampleSummaryUnitCount(newSummary.getId());
   }
@@ -268,7 +268,7 @@ public class SampleServiceTest {
   @Test
   public void createSampleUnit() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     verify(sampleUnitRepository, times(1)).save(any(SampleUnit.class));
@@ -277,7 +277,7 @@ public class SampleServiceTest {
   @Test
   public void createDuplicateSampleUnitThrowsIllegalStateException() throws UnknownSampleSummaryException {
     SampleSummary newSummary = createSampleSummary(5, 2);
-    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+    when(sampleSummaryRepository.findSampleSummaryById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     SampleUnit sampleUnit = sampleService.createSampleUnit(newSummary.getId(), businessSampleUnit, SampleUnitState.INIT);
     when(sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(businessSampleUnit.getSampleUnitRef(), newSummary.getSampleSummaryPK())).thenReturn(true);


### PR DESCRIPTION
# What and why?
JPA in Spring Boot 2.4 requires findById to return Optional

# How to test?
Run acceptance tests

# Trello
https://trello.com/c/GsbrJG9u/572-s31a-spring-boot-2-upgrade-sample-service
