### PR TITLE
Include the update state calls within the same database transaction

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.4.0
+appVersion: 11.4.1

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -263,11 +263,13 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
 
     log.debug("business sample constructed", kv("businessSample", businessSampleUnit));
     try {
+      // first create the new sample
       SampleUnit sampleUnit =
           sampleService.createSampleUnit(
               sampleSummaryId, businessSampleUnit, SampleUnitDTO.SampleUnitState.INIT);
       log.debug("sample created");
-
+      // check the state of the sample summary
+      sampleService.sampleSummaryStateCheck(sampleUnit);
       SampleUnitDTO sampleUnitDTO = mapperFacade.map(sampleUnit, SampleUnitDTO.class);
       log.debug("created SampleUnitDTO", kv("sampleUnitDTO", sampleUnitDTO));
       return ResponseEntity.created(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -267,7 +267,6 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
           sampleService.createSampleUnit(
               sampleSummaryId, businessSampleUnit, SampleUnitDTO.SampleUnitState.INIT);
       log.debug("sample created");
-      sampleService.updateState(sampleUnit);
 
       SampleUnitDTO sampleUnitDTO = mapperFacade.map(sampleUnit, SampleUnitDTO.class);
       log.debug("created SampleUnitDTO", kv("sampleUnitDTO", sampleUnitDTO));
@@ -281,7 +280,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     } catch (UnknownSampleSummaryException e) {
       log.error("unknown sample summary id", kv("sampleSummaryId", sampleSummaryId), e);
       return ResponseEntity.badRequest().build();
-    } catch (CTPException e) {
+    } catch (CTPException | RuntimeException e) {
       log.error("unexpected exception", kv("sampleSummaryId", sampleSummaryId), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -72,7 +72,7 @@ public class SampleService {
   @Transactional(propagation = Propagation.REQUIRED)
   public SampleUnit createSampleUnit(
       UUID sampleSummaryId, BusinessSampleUnit samplingUnit, SampleUnitState sampleUnitState)
-      throws UnknownSampleSummaryException {
+      throws UnknownSampleSummaryException, CTPException {
 
     SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElse(null);
     if (sampleSummary != null) {
@@ -84,7 +84,10 @@ public class SampleService {
           sampleUnitRepository.existsBySampleUnitRefAndSampleSummaryFK(
               samplingUnit.getSampleUnitRef(), sampleSummary.getSampleSummaryPK());
       if (!exists) {
-        return createAndSaveSampleUnit(sampleSummary, sampleUnitState, samplingUnit);
+        SampleUnit sampleUnit =
+            createAndSaveSampleUnit(sampleSummary, sampleUnitState, samplingUnit);
+        updateState(sampleUnit);
+        return sampleUnit;
       } else {
         throw new IllegalStateException("sample unit already exists");
       }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -159,6 +159,7 @@ public class SampleService {
    * @return SampleSummary the updated SampleSummary
    * @throws CTPException if transition errors
    */
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = false)
   public SampleSummary activateSampleSummaryState(Integer sampleSummaryPK) throws CTPException {
     log.debug("attempting to find sample summary", kv("sampleSummaryPK", sampleSummaryPK));
     try {
@@ -179,7 +180,6 @@ public class SampleService {
 
   public void updateState(SampleUnit sampleUnit) throws CTPException {
     changeSampleUnitState(sampleUnit);
-    sampleSummaryStateCheck(sampleUnit);
   }
 
   private void changeSampleUnitState(SampleUnit sampleUnit) throws CTPException {
@@ -190,7 +190,7 @@ public class SampleService {
     sampleUnitRepository.saveAndFlush(sampleUnit);
   }
 
-  private void sampleSummaryStateCheck(SampleUnit sampleUnit) throws CTPException {
+  public void sampleSummaryStateCheck(SampleUnit sampleUnit) throws CTPException {
     int partied =
         sampleUnitRepository.countBySampleSummaryFKAndState(
             sampleUnit.getSampleSummaryFK(), SampleUnitState.PERSISTED);

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import libs.common.FixtureHelper;
+import libs.common.error.CTPException;
 import libs.common.state.StateTransitionManager;
 import libs.sample.validation.BusinessSampleUnit;
 import org.junit.Before;
@@ -165,7 +166,8 @@ public class SampleServiceTest {
 
     newSummary.setTotalSampleUnits(numSamples);
     newSummary.setExpectedCollectionInstruments(expectedInstruments);
-
+    newSummary.setSampleSummaryPK(1);
+    when(this.sampleSummaryRepository.findBySampleSummaryPK(1)).thenReturn(Optional.of(newSummary));
     return newSummary;
   }
 
@@ -229,7 +231,7 @@ public class SampleServiceTest {
   }
 
   @Test
-  public void createSampleUnit() throws UnknownSampleSummaryException {
+  public void createSampleUnit() throws UnknownSampleSummaryException, CTPException {
     SampleSummary newSummary = createSampleSummary(5, 2);
     when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
@@ -239,7 +241,7 @@ public class SampleServiceTest {
 
   @Test
   public void createDuplicateSampleUnitThrowsIllegalStateException()
-      throws UnknownSampleSummaryException {
+      throws UnknownSampleSummaryException, CTPException {
     SampleSummary newSummary = createSampleSummary(5, 2);
     when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
@@ -261,7 +263,8 @@ public class SampleServiceTest {
   }
 
   @Test(expected = UnknownSampleSummaryException.class)
-  public void createSampleUnitWithUnknownSampleSummary() throws UnknownSampleSummaryException {
+  public void createSampleUnitWithUnknownSampleSummary()
+      throws UnknownSampleSummaryException, CTPException {
     BusinessSampleUnit businessSampleUnit = new BusinessSampleUnit();
     sampleService.createSampleUnit(UUID.randomUUID(), businessSampleUnit, SampleUnitState.INIT);
   }
@@ -286,7 +289,7 @@ public class SampleServiceTest {
 
   @Test(expected = UnknownSampleSummaryException.class)
   public void findSampleUnitWithUnknownSampleSummary()
-      throws UnknownSampleSummaryException, UnknownSampleUnitException {
+      throws UnknownSampleSummaryException, UnknownSampleUnitException, CTPException {
 
     SampleSummary newSummary = createSampleSummary(5, 2);
     when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(null));

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -127,6 +127,7 @@ public class SampleServiceTest {
         .thenReturn(SampleState.ACTIVE);
 
     sampleService.updateState(sampleUnit.get(0));
+    sampleService.activateSampleSummaryState(1);
     assertThat(sampleUnit.get(0).getState(), is(SampleUnitState.PERSISTED));
     assertThat(sampleSummaryList.get(0).getState(), is(SampleState.ACTIVE));
   }
@@ -167,7 +168,6 @@ public class SampleServiceTest {
     newSummary.setTotalSampleUnits(numSamples);
     newSummary.setExpectedCollectionInstruments(expectedInstruments);
     newSummary.setSampleSummaryPK(1);
-    when(this.sampleSummaryRepository.findBySampleSummaryPK(1)).thenReturn(Optional.of(newSummary));
     return newSummary;
   }
 


### PR DESCRIPTION
# What and why?
Including the update state calls within the same database transaction to stop the sceranio where a sample unit can be stuck in INIT state and therefore not distributed to collection exercise.

# How to test?
Run acceptance tests

# Trello
NA