### PR TITLE
Fix activate sample summary check

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.4.1
+appVersion: 11.4.2

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -112,23 +112,35 @@ public class SampleServiceTest {
   }
 
   /**
-   * Test that when a Party is posted to Party Service the appropriate states are changed
+   * Test that when a sample unit is in the correct state
    *
    * @throws Exception oops
    */
   @Test
-  public void updateStatesTest() throws Exception {
+  public void updateStateTest() throws Exception {
     when(sampleSvcUnitStateTransitionManager.transition(
             SampleUnitState.INIT, SampleUnitEvent.PERSISTING))
         .thenReturn(SampleUnitState.PERSISTED);
+
+    sampleService.updateState(sampleUnit.get(0));
+    assertThat(sampleUnit.get(0).getState(), is(SampleUnitState.PERSISTED));
+  }
+
+  /**
+   * Test that a sample summary is activated when all sample units are created.
+   *
+   * @throws Exception oops
+   */
+  @Test
+  public void activateSampleSummaryTest() throws Exception {
+    when(sampleUnitRepository.countBySampleSummaryFKAndState(1, SampleUnitState.PERSISTED))
+        .thenReturn(1);
     when(sampleSummaryRepository.findBySampleSummaryPK(1))
         .thenReturn(Optional.of(sampleSummaryList.get(0)));
     when(sampleSvcStateTransitionManager.transition(SampleState.INIT, SampleEvent.ACTIVATED))
         .thenReturn(SampleState.ACTIVE);
 
-    sampleService.updateState(sampleUnit.get(0));
-    sampleService.activateSampleSummaryState(1);
-    assertThat(sampleUnit.get(0).getState(), is(SampleUnitState.PERSISTED));
+    sampleService.sampleSummaryStateCheck(sampleUnit.get(0));
     assertThat(sampleSummaryList.get(0).getState(), is(SampleState.ACTIVE));
   }
 

--- a/src/test/resources/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.SampleSummary.json
+++ b/src/test/resources/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.SampleSummary.json
@@ -2,6 +2,7 @@
 	{
 		"sampleSummaryPK": 1,
 		"state": "INIT",
-		"id":"14fb3e68-4dca-46db-bf49-04b84e07e77f"
+		"id":"14fb3e68-4dca-46db-bf49-04b84e07e77f",
+		"totalSampleUnits": 1
 	}
 ]


### PR DESCRIPTION
# What and why?
The original sample summary check method use to check the number of sample units for a given sample summary in PERSISTED state against the total number of sample units created for that sample summary in any state. This worked before as a sample unit was only moved to PERSISTED state once a request had been sent to party. As the rabbit queue for sending requests to party acted like a throttle it meant all sample units were created before the requests to party was completed and this check worked.

However this no longer works as csv-worker is creating the party objects at the same time as the sample units, so we end up trying to activate the sample summary multiple times resulting in transition errors.

What the check actually should be, and probably should have been from the beginning is to check that the number of sample units in PERSISTED state matches the total sample unit count on the sample summary itself. Once the system has all the sample units for a sample summary then that sample summary can be activated.

# How to test?
Run acceptance tests

# Trello
NA