### PR TITLE
Change party url to business url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, sample-v2 ]
 env:
   IMAGE: sample
   REGISTRY_HOSTNAME: eu.gcr.io

--- a/src/main/java/uk/gov/ons/ctp/response/client/PartySvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/PartySvcClient.java
@@ -39,7 +39,6 @@ public class PartySvcClient {
   /**
    * Request party from the Party Service
    *
-   * @param sampleUnitType the sample unit type for which to request party
    * @param sampleUnitRef the sample unit ref for which to request party
    * @return the party object
    */
@@ -47,14 +46,11 @@ public class PartySvcClient {
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-  public PartyDTO requestParty(String sampleUnitType, String sampleUnitRef) {
-    log.debug(
-        "Retrieving party",
-        kv("sample_unit_type", sampleUnitType),
-        kv("sample_unit_ref", sampleUnitRef));
+  public PartyDTO requestParty(String sampleUnitRef) {
+    log.debug("Retrieving party", kv("sample_unit_ref", sampleUnitRef));
     UriComponents uriComponents =
         restUtility.createUriComponents(
-            appConfig.getPartySvc().getRequestPartyPath(), null, sampleUnitType, sampleUnitRef);
+            appConfig.getPartySvc().getRequestPartyPath(), null, sampleUnitRef);
     HttpEntity<PartyDTO> httpEntity = restUtility.createHttpEntityWithAuthHeader();
     ResponseEntity<PartyDTO> responseEntity =
         restTemplate.exchange(uriComponents.toUri(), HttpMethod.GET, httpEntity, PartyDTO.class);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentService.java
@@ -162,7 +162,7 @@ public class SampleSummaryEnrichmentService {
   }
 
   private boolean findAndUpdateParty(String surveyId, SampleUnit sampleUnit, UUID sampleUnitId) {
-    PartyDTO party = getParty(sampleUnit);
+    PartyDTO party = getParty(sampleUnit.getSampleUnitRef());
     boolean foundParty = (party != null && party.getId() != null);
     if (foundParty) {
       // save the party id against the sample
@@ -246,24 +246,21 @@ public class SampleSummaryEnrichmentService {
   /**
    * Return the party object for a specific sample
    *
-   * @param sampleUnit the sample unit to find the party object for
    * @return the party object
    */
-  private PartyDTO getParty(SampleUnit sampleUnit) {
+  private PartyDTO getParty(String sampleUnitRef) {
     try {
-      PartyDTO party =
-          partySvcClient.requestParty(
-              sampleUnit.getSampleUnitType(), sampleUnit.getSampleUnitRef());
+      PartyDTO party = partySvcClient.requestParty(sampleUnitRef);
       return party;
     } catch (HttpClientErrorException e) {
       if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
         LOG.error(
             "Unexpected HTTP response code from party service",
-            kv("sampleUnit", sampleUnit),
+            kv("sampleUnit", sampleUnitRef),
             kv("status_code", e.getStatusCode()));
         throw e;
       } else {
-        LOG.error("party does not exist for sample", kv("sampleUnit", sampleUnit));
+        LOG.error("party does not exist for sample", kv("sampleUnit", sampleUnitRef));
         return null;
       }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,7 +109,7 @@ collection-instrument-svc:
 
 
 party-svc:
-  request-party-path: /party-api/v1/parties/type/{sampleUnitType}/ref/{sampleUnitRef}
+  request-party-path: /party-api/v1/businesses/ref/{sampleUnitRef}
   connection-config:
     scheme: http
     host: localhost

--- a/src/test/java/uk/gov/ons/ctp/response/sample/client/PartySvcClientTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/client/PartySvcClientTest.java
@@ -25,7 +25,6 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.ons.ctp.response.client.PartySvcClient;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.config.PartySvc;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PartySvcClientTest {
@@ -57,7 +56,7 @@ public class PartySvcClientTest {
         .thenReturn(new ResponseEntity<>(HttpStatus.CREATED));
 
     // When
-    partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B.toString(), SAMPLE_UNIT_REF);
+    partySvcClient.requestParty(SAMPLE_UNIT_REF);
 
     // Then
     verify(restTemplate, times(1))
@@ -72,7 +71,7 @@ public class PartySvcClientTest {
         .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 
     // When
-    partySvcClient.requestParty(SampleUnitDTO.SampleUnitType.B.toString(), SAMPLE_UNIT_REF);
+    partySvcClient.requestParty(SAMPLE_UNIT_REF);
 
     // Then
     verify(restTemplate, times(1))

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentServiceTest.java
@@ -93,7 +93,7 @@ public class SampleSummaryEnrichmentServiceTest {
     List<CollectionInstrumentDTO> collectionInstruments = new ArrayList<>();
     collectionInstruments.add(collectionInstrumentDTO);
 
-    when(partySvcClient.requestParty(sampleUnitType, sampleUnitRef)).thenReturn(partyDTO);
+    when(partySvcClient.requestParty(sampleUnitRef)).thenReturn(partyDTO);
     when(surveySvcClient.requestClassifierTypeSelectors(surveyId)).thenReturn(classifiers);
     when(surveySvcClient.requestClassifierTypeSelector(surveyId, classifierId))
         .thenReturn(classifierTypeDTO);
@@ -106,7 +106,7 @@ public class SampleSummaryEnrichmentServiceTest {
     boolean enriched =
         sampleSummaryEnrichmentService.enrich(surveyId, sampleSummaryId, collectionExerciseId);
     assertTrue("sample summary should be enriched", enriched);
-    verify(partySvcClient, times(1)).requestParty(sampleUnitType, sampleUnitRef);
+    verify(partySvcClient, times(1)).requestParty(sampleUnitRef);
   }
 
   /**
@@ -138,7 +138,7 @@ public class SampleSummaryEnrichmentServiceTest {
     when(sampleUnitRepository.findBySampleSummaryFKAndState(
             1, SampleUnitDTO.SampleUnitState.PERSISTED))
         .thenReturn(samples.stream());
-    when(partySvcClient.requestParty(sampleUnitType, sampleUnitRef))
+    when(partySvcClient.requestParty(sampleUnitRef))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Not found"));
 
     boolean enriched =
@@ -188,7 +188,7 @@ public class SampleSummaryEnrichmentServiceTest {
     classifierTypes.add("FORM_TYPE");
     classifierTypeDTO.setClassifierTypes(classifierTypes);
 
-    when(partySvcClient.requestParty(sampleUnitType, sampleUnitRef)).thenReturn(partyDTO);
+    when(partySvcClient.requestParty(sampleUnitRef)).thenReturn(partyDTO);
     when(surveySvcClient.requestClassifierTypeSelectors(surveyId)).thenReturn(classifiers);
     when(surveySvcClient.requestClassifierTypeSelector(surveyId, classifierId))
         .thenReturn(classifierTypeDTO);
@@ -201,7 +201,7 @@ public class SampleSummaryEnrichmentServiceTest {
     boolean enriched =
         sampleSummaryEnrichmentService.enrich(surveyId, sampleSummaryId, collectionExerciseId);
     assertFalse("sample summary should not be enriched", enriched);
-    verify(partySvcClient, times(1)).requestParty(sampleUnitType, sampleUnitRef);
+    verify(partySvcClient, times(1)).requestParty(sampleUnitRef);
   }
 
   /**


### PR DESCRIPTION
# What and why?
The /parties/type/{type}/ref/{ref} endpoint in party is being removed in favour of /businesses/ref/{ref}. This PR changes over to it. Functionally there should be no change as those 2 endpoints have been mapped to the same function in party for months now.


# How to test?

# Trello
