### PR TITLE
Remove cacheable collection instrument

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionInstrumentSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionInstrumentSvcClient.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.client;
 
-
 import java.util.List;
 import libs.collection.instrument.representation.CollectionInstrumentDTO;
 import libs.common.rest.RestUtility;

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionInstrumentSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionInstrumentSvcClient.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.client;
 
-import static uk.gov.ons.ctp.response.sample.SampleSvcApplication.COLLECTION_INSTRUMENT_CACHE;
 
 import java.util.List;
 import libs.collection.instrument.representation.CollectionInstrumentDTO;
@@ -8,7 +7,6 @@ import libs.common.rest.RestUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -51,7 +49,6 @@ public class CollectionInstrumentSvcClient {
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-  @Cacheable(COLLECTION_INSTRUMENT_CACHE)
   public List<CollectionInstrumentDTO> requestCollectionInstruments(String searchString) {
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("searchString", searchString);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -42,8 +42,6 @@ import uk.gov.ons.ctp.response.sample.service.state.SampleSvcStateTransitionMana
 @EnableAsync
 public class SampleSvcApplication {
 
-  public static final String COLLECTION_INSTRUMENT_CACHE = "collectioninstruments";
-
   @Autowired private StateTransitionManagerFactory stateTransitionManager;
 
   @Autowired private AppConfig appConfig;


### PR DESCRIPTION
# What and why?
Removing cacheable from the collection instrument service client as it causes the acceptance tests to fail if you re-run them

# How to test?
Run acceptance test more than once

# Trello
https://trello.com/c/lsGFcRzR/440-s39-ce-sample-distribution-phase