### PR TITLE
Add sample unit state change on delivery to case

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.6
+version: 12.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.6
+appVersion: 12.0.7

--- a/diagrams/sample-unit-state.puml
+++ b/diagrams/sample-unit-state.puml
@@ -5,5 +5,5 @@ skinparam state {
 
 [*] --> INIT
 INIT --> PERSISTED : persisting [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java#L201 *]]
-PERSISTED --> DELIVERED : delivering [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java#L146 *]]
+PERSISTED --> DELIVERED : delivering [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleDistributionService.java#L103 *]]
 @enduml

--- a/diagrams/sample-unit-state.puml
+++ b/diagrams/sample-unit-state.puml
@@ -5,5 +5,5 @@ skinparam state {
 
 [*] --> INIT
 INIT --> PERSISTED : persisting [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java#L201 *]]
-PERSISTED --> DELIVERED : delivering [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleDistributionService.java#L103 *]]
+PERSISTED --> DELIVERED : delivering to case [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleDistributionService.java#L103 *]]
 @enduml

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -4,14 +4,19 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 
 import java.util.List;
 import java.util.UUID;
+import libs.common.error.CTPException;
+import libs.common.state.StateTransitionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitParentDTO;
 
 @Service
@@ -22,6 +27,12 @@ public class SampleSummaryDistributionService {
   @Autowired private SampleService sampleService;
   @Autowired private SampleUnitPublisher sampleUnitPublisher;
   @Autowired private SampleSummaryRepository sampleSummaryRepository;
+  @Autowired private SampleUnitRepository sampleUnitRepository;
+
+  @Autowired
+  @Qualifier("sampleUnitTransitionManager")
+  private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent>
+      sampleUnitTransitionManager;
 
   /**
    * Distributes the sample units to the case service to create cases against each sample unit. This
@@ -55,6 +66,7 @@ public class SampleSummaryDistributionService {
         sampleUnit -> {
           try {
             distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
+
           } catch (RuntimeException ex) {
             LOG.error(
                 "Failed to distribute sample unit", kv("SampleSummaryId", sampleSummaryId), ex);
@@ -81,6 +93,20 @@ public class SampleSummaryDistributionService {
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
+    try {
+      LOG.debug(
+          "Transitioning state of sampleUnit",
+          kv("SampleUnit", sampleUnit),
+          kv("from", sampleUnit.getState()),
+          kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
+      SampleUnitDTO.SampleUnitState newState =
+          sampleUnitTransitionManager.transition(
+              sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
+      sampleUnit.setState(newState);
+      sampleUnitRepository.saveAndFlush(sampleUnit);
+    } catch (CTPException e) {
+      LOG.error("Error occurred whilst transitioning state", e);
+    }
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -94,9 +94,9 @@ public class SampleSummaryDistributionService {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
     try {
-      LOG.debug(
+      LOG.info(
           "Transitioning state of sampleUnit",
-          kv("SampleUnit", sampleUnit),
+          kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
       SampleUnitDTO.SampleUnitState newState =

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionServiceTest.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import libs.common.error.CTPException;
+import libs.common.state.StateTransitionManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -15,7 +17,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
+import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
+import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitParentDTO;
 
 /** tests */
@@ -30,6 +34,12 @@ public class SampleSummaryDistributionServiceTest {
   private static final String SAMPLE_UNIT_TYPE = "B";
 
   @Mock private SampleSummaryRepository sampleSummaryRepository;
+  @Mock private SampleUnitRepository sampleUnitRepository;
+
+  @Mock
+  private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent>
+      sampleUnitStateTransitionManager;
+
   @Mock private SampleUnitPublisher sampleUnitPublisher;
   @Mock private SampleService sampleService;
 
@@ -38,7 +48,7 @@ public class SampleSummaryDistributionServiceTest {
 
   @Test
   public void testDistribute()
-      throws UnknownSampleSummaryException, NoSampleUnitsInSampleSummaryException {
+      throws UnknownSampleSummaryException, NoSampleUnitsInSampleSummaryException, CTPException {
     SampleSummary sampleSummary = new SampleSummary();
     sampleSummary.setId(SAMPLE_SUMMARY_ID);
     sampleSummary.setSampleSummaryPK(1);
@@ -58,6 +68,8 @@ public class SampleSummaryDistributionServiceTest {
 
     sampleSummaryDistributionService.distribute(SAMPLE_SUMMARY_ID);
     verify(sampleUnitPublisher, times(1)).sendSampleUnitToCase(any());
+    verify(sampleUnitStateTransitionManager, times(1)).transition(any(), any());
+    verify(sampleUnitRepository, times(1)).saveAndFlush(any());
     verify(sampleSummaryRepository, times(1)).saveAndFlush(any());
   }
 


### PR DESCRIPTION
# What and why?
When changing to sample v2, I forgot to change the state of the sample unit once it was sent.  Before this PR it would stay at PERSISTED, now it changes form PERSISTED to DELIVERED once it's been sent to case.

Note:  DELIVERED used to mean 'sent to collection exercise', where it would be sent from collection exercise to case.  Now DELIVERED means 'sent to case'
# How to test?

# Trello
