### PR TITLE
Use parallelStream to send samples to case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -1,8 +1,8 @@
 package uk.gov.ons.ctp.response.sample.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/domain/repository/SampleSummaryRepository.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.sample.domain.repository;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
@@ -16,7 +17,7 @@ public interface SampleSummaryRepository extends JpaRepository<SampleSummary, In
    * @param id the UUID of the sampleSummary
    * @return SampleSummary object
    */
-  Optional<SampleSummary> findById(UUID id);
+  List<SampleSummary> findById(UUID id);
 
   Optional<SampleSummary> findBySampleSummaryPK(Integer sampleSummaryPK);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -62,7 +62,6 @@ public class SampleUnitDistributor {
                   sampleSummary ->
                       sampleUnitRepository.findBySampleSummaryFKAndState(
                           sampleSummary.getSampleSummaryPK(), SampleUnitState.PERSISTED))
-              .orElseGet(Stream::empty)
               .map(
                   sampleUnit ->
                       sampleUnitMapper.mapSampleUnit(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -13,38 +13,30 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ctp.response.sample.domain.model.CollectionExerciseJob;
+import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.repository.CollectionExerciseJobRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO.SampleState;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO.SampleUnitState;
 import uk.gov.ons.ctp.response.sampleunit.definition.SampleUnit;
-import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 
-/**
- * Distributes SampleUnits to Collex when requested via job. Retries failures
- * until successful
- */
+/** Distributes SampleUnits to Collex when requested via job. Retries failures until successful */
 @Component
 public class SampleUnitDistributor {
   private static final Logger log = LoggerFactory.getLogger(SampleUnitDistributor.class);
 
   private static final int TRANSACTION_TIMEOUT_SECONDS = 3600;
 
-  @Autowired
-  private SampleUnitSender sampleUnitSender;
+  @Autowired private SampleUnitSender sampleUnitSender;
 
-  @Autowired
-  private CollectionExerciseJobRepository collectionExerciseJobRepository;
+  @Autowired private CollectionExerciseJobRepository collectionExerciseJobRepository;
 
-  @Autowired
-  private SampleUnitRepository sampleUnitRepository;
+  @Autowired private SampleUnitRepository sampleUnitRepository;
 
-  @Autowired
-  private SampleSummaryRepository sampleSummaryRepository;
+  @Autowired private SampleSummaryRepository sampleSummaryRepository;
 
-  @Autowired
-  private SampleUnitMapper sampleUnitMapper;
+  @Autowired private SampleUnitMapper sampleUnitMapper;
 
   /** Scheduled job for distributing SampleUnits */
   @Transactional(timeout = TRANSACTION_TIMEOUT_SECONDS)
@@ -93,9 +85,9 @@ public class SampleUnitDistributor {
   }
 
   /**
-   * Publish a SampleUnit. If it passes then return true otherwise false. This
-   * will mimick the previous functionality and allow us to obtain a collection of
-   * the Sample units that fail for better logging.
+   * Publish a SampleUnit. If it passes then return true otherwise false. This will mimick the
+   * previous functionality and allow us to obtain a collection of the Sample units that fail for
+   * better logging.
    *
    * @return Predicate<SampleUnit>
    */
@@ -105,8 +97,11 @@ public class SampleUnitDistributor {
         sampleUnitSender.sendSampleUnit(mappedSampleUnit);
         return true;
       } catch (CTPException e) {
-        log.error("Failed to send a sample unit to queue and update state",
-            kv("sample_unit_id", mappedSampleUnit.getId()), "exception", e);
+        log.error(
+            "Failed to send a sample unit to queue and update state",
+            kv("sample_unit_id", mappedSampleUnit.getId()),
+            "exception",
+            e);
         return false;
       }
     };

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -51,8 +51,7 @@ public class SampleUnitDistributor {
     UUID sampleSummaryId = job.getSampleSummaryId();
     try {
       List<SampleUnit> invalidSamples =
-          sampleSummaryRepository.findById(sampleSummaryId)
-              .parallelStream()
+          sampleSummaryRepository.findById(sampleSummaryId).parallelStream()
               .filter(sampleSummary -> sampleSummary.getState() == SampleState.ACTIVE)
               .map(
                   sampleSummary ->

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -5,7 +5,6 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import libs.common.error.CTPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/scheduled/distribution/SampleUnitDistributor.java
@@ -51,8 +51,8 @@ public class SampleUnitDistributor {
     UUID sampleSummaryId = job.getSampleSummaryId();
     try {
       List<SampleUnit> invalidSamples =
-          Optional.of(sampleSummaryRepository.findById(sampleSummaryId))
-              .orElseThrow()
+          sampleSummaryRepository.findById(sampleSummaryId)
+              .parallelStream()
               .filter(sampleSummary -> sampleSummary.getState() == SampleState.ACTIVE)
               .map(
                   sampleSummary ->


### PR DESCRIPTION
# What and why?
We currently process sample jobs one sample at a time. This is a potential candidate for parallelism (though it should be noted that `.parallelStream()` has a much bigger overhead compared to `.stream()`

# How to test?

# Trello
https://trello.com/c/hQ3pazls/888-s42-use-parallelstreams-to-send-samples-to-case