### PR TITLE
Sample Unit validation

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.0.7
+version: 12.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.7
+appVersion: 12.0.8

--- a/diagrams/sample-summary-state.puml
+++ b/diagrams/sample-summary-state.puml
@@ -4,6 +4,6 @@ skinparam state {
 }
 
 [*] --> INIT
-INIT --> ACTIVE : activated [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java#L180 *]]
-INIT --> FAILED : fail_validation [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java#L286 *]]
+INIT --> ACTIVE : activated
+ACTIVE --> FAILED : fail_validation
 @enduml

--- a/diagrams/sample-unit-state.puml
+++ b/diagrams/sample-unit-state.puml
@@ -4,6 +4,7 @@ skinparam state {
 }
 
 [*] --> INIT
-INIT --> PERSISTED : persisting [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/impl/SampleServiceImpl.java#L201 *]]
-PERSISTED --> DELIVERED : delivering to case [[https://github.com/ONSdigital/rm-sample-service/blob/main/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleDistributionService.java#L103 *]]
+INIT --> PERSISTED : persisting
+PERSISTED --> DELIVERED : delivering to case
+PERSISTED --> FAILED : failed to enrich
 @enduml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -194,11 +194,11 @@ paths:
             example: 34597808-ec88-4e93-af2f-228e33ff7946
         - in: query
           name: state
+          description: only return sample units that have the requested state
           required: false
           schema:
             type: string
             example: FAILED
-          description: only returned sample units that have the requested state
       responses:
         '200':
           description: The respondent was retrieved successfully.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -192,6 +192,13 @@ paths:
             type: string
             format: uuid
             example: 34597808-ec88-4e93-af2f-228e33ff7946
+        - in: query
+          name: state
+          required: false
+          schema:
+            type: string
+            example: FAILED
+          description: only returned sample units that have the requested state
       responses:
         '200':
           description: The respondent was retrieved successfully.

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -14,6 +14,7 @@ import libs.common.error.InvalidRequestException;
 import libs.common.time.DateTimeUtil;
 import libs.sample.validation.BusinessSampleUnit;
 import ma.glasnost.orika.MapperFacade;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -187,7 +188,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       throws CTPException {
 
     List<SampleUnit> sampleUnits;
-    if (state == null) {
+    if (Strings.isEmpty(state)) {
       sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
     } else {
       try {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -191,12 +191,24 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     if (Strings.isEmpty(state)) {
       sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
     } else {
+      log.debug(
+          "finding samples with state", kv("sampleSummaryId", sampleSummaryId), kv("state", state));
       try {
         SampleUnitDTO.SampleUnitState sampleUnitState =
             SampleUnitDTO.SampleUnitState.valueOf(state);
         sampleUnits =
             sampleService.findSampleUnitsBySampleSummaryAndState(sampleSummaryId, sampleUnitState);
+        log.info(
+            "found samples with state",
+            kv("sampleSummaryId", sampleSummaryId),
+            kv("state", state),
+            kv("numberOfSamples", sampleUnits.size()));
       } catch (IllegalArgumentException | NullPointerException e) {
+        log.error(
+            "failed to find samples with state",
+            kv("sampleSummaryId", sampleSummaryId),
+            kv("state", state),
+            e);
         throw new CTPException(
             CTPException.Fault.BAD_REQUEST, String.format("%s is not a valid state", state));
       }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -190,6 +190,16 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     List<SampleUnit> sampleUnits;
     if (Strings.isEmpty(state)) {
       sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
+
+      List<SampleUnitDTO> result = mapperFacade.mapAsList(sampleUnits, SampleUnitDTO.class);
+
+      if (!sampleUnits.isEmpty()) {
+        return ResponseEntity.ok(result.toArray(new SampleUnitDTO[] {}));
+      }
+
+      throw new CTPException(
+          CTPException.Fault.BAD_REQUEST,
+          String.format("No sample units were found for sample summary %s", sampleSummaryId));
     } else {
       log.debug(
           "finding samples with state", kv("sampleSummaryId", sampleSummaryId), kv("state", state));
@@ -203,6 +213,11 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
             kv("sampleSummaryId", sampleSummaryId),
             kv("state", state),
             kv("numberOfSamples", sampleUnits.size()));
+
+        List<SampleUnitDTO> result = mapperFacade.mapAsList(sampleUnits, SampleUnitDTO.class);
+
+        return ResponseEntity.ok(result.toArray(new SampleUnitDTO[] {}));
+
       } catch (IllegalArgumentException | NullPointerException e) {
         log.error(
             "failed to find samples with state",
@@ -213,16 +228,6 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
             CTPException.Fault.BAD_REQUEST, String.format("%s is not a valid state", state));
       }
     }
-
-    List<SampleUnitDTO> result = mapperFacade.mapAsList(sampleUnits, SampleUnitDTO.class);
-
-    if (!sampleUnits.isEmpty()) {
-      return ResponseEntity.ok(result.toArray(new SampleUnitDTO[] {}));
-    }
-
-    throw new CTPException(
-        CTPException.Fault.BAD_REQUEST,
-        String.format("No sample units were found for sample summary %s", sampleSummaryId));
   }
 
   @RequestMapping(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -182,9 +182,24 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
 
   @RequestMapping(value = "{sampleSummaryId}/sampleunits", method = RequestMethod.GET)
   public ResponseEntity<SampleUnitDTO[]> requestSampleUnitsForSampleSummary(
-      @PathVariable("sampleSummaryId") final UUID sampleSummaryId) throws CTPException {
+      @PathVariable("sampleSummaryId") final UUID sampleSummaryId,
+      @RequestParam(required = false) String state)
+      throws CTPException {
 
-    List<SampleUnit> sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
+    List<SampleUnit> sampleUnits;
+    if (state == null) {
+      sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
+    } else {
+      try {
+        SampleUnitDTO.SampleUnitState sampleUnitState =
+            SampleUnitDTO.SampleUnitState.valueOf(state);
+        sampleUnits =
+            sampleService.findSampleUnitsBySampleSummaryAndState(sampleSummaryId, sampleUnitState);
+      } catch (IllegalArgumentException | NullPointerException e) {
+        throw new CTPException(
+            CTPException.Fault.BAD_REQUEST, String.format("%s is not a valid state", state));
+      }
+    }
 
     List<SampleUnitDTO> result = mapperFacade.mapAsList(sampleUnits, SampleUnitDTO.class);
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleSummaryActivation.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleSummaryActivation.java
@@ -14,7 +14,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.sample.representation.SampleSummaryActivationDTO;
-import uk.gov.ons.ctp.response.sample.service.*;
+import uk.gov.ons.ctp.response.sample.service.SampleSummaryActivationException;
+import uk.gov.ons.ctp.response.sample.service.SampleSummaryActivationService;
+import uk.gov.ons.ctp.response.sample.service.SampleSummaryEnrichmentService;
 
 /** PubSub subscription responsible for sample summary activation via PubSub. */
 @Component

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -260,6 +260,7 @@ public class SampleService {
     }
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<SampleUnit> findSampleUnitsBySampleSummaryAndState(
       UUID sampleSummaryId, SampleUnitState state) {
     try {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.response.sample.service;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import libs.common.error.CTPException;
 import libs.common.state.StateTransitionManager;
 import libs.common.time.DateTimeUtil;
@@ -243,43 +244,10 @@ public class SampleService {
     return sampleUnitsTotal;
   }
 
-  public Optional<SampleSummary> failSampleSummary(SampleSummary sampleSummary, String message) {
-    try {
-      SampleState newState =
-          sampleSvcStateTransitionManager.transition(
-              sampleSummary.getState(), SampleEvent.FAIL_VALIDATION);
-      sampleSummary.setState(newState);
-      sampleSummary.setNotes(message);
-      SampleSummary persisted = this.sampleSummaryRepository.save(sampleSummary);
-
-      return Optional.of(persisted);
-    } catch (CTPException e) {
-      log.error(
-          "Failed to put sample summary into FAILED state",
-          kv("sample_summary", sampleSummary.getId()),
-          e);
-
-      return Optional.empty();
-    } catch (RuntimeException e) {
-      // Hibernate throws RuntimeException if any issue persisting the SampleSummary. This is to
-      // ensure it is logged
-      // (otherwise they just disappear).
-      log.error("Failed to persist sample summary - {}", e);
-
-      throw e;
-    }
-  }
-
-  public Optional<SampleSummary> failSampleSummary(
-      SampleSummary sampleSummary, Exception exception) {
-    return failSampleSummary(sampleSummary, exception.getMessage());
-  }
-
   // TODO get this to get the attributes in a separate call then stitch the results into the value
   // returned by sampleUnitRepository.findById
   public SampleUnit findSampleUnit(UUID id) {
-    SampleUnit su = sampleUnitRepository.findById(id).orElse(null);
-    return su;
+    return sampleUnitRepository.findById(id).orElse(null);
   }
 
   public List<SampleUnit> findSampleUnitsBySampleSummary(UUID sampleSummaryId) {
@@ -287,6 +255,22 @@ public class SampleService {
       SampleSummary ss = sampleSummaryRepository.findById(sampleSummaryId).orElseThrow();
       return sampleUnitRepository.findBySampleSummaryFK(ss.getSampleSummaryPK());
     } catch (NoSuchElementException e) {
+      log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));
+      return new ArrayList<>();
+    }
+  }
+
+  public List<SampleUnit> findSampleUnitsBySampleSummaryAndState(
+      UUID sampleSummaryId, SampleUnitState state) {
+    try {
+      SampleSummary ss =
+          sampleSummaryRepository
+              .findById(sampleSummaryId)
+              .orElseThrow(UnknownSampleSummaryException::new);
+      return sampleUnitRepository
+          .findBySampleSummaryFKAndState(ss.getSampleSummaryPK(), state)
+          .collect(Collectors.toList());
+    } catch (UnknownSampleSummaryException e) {
       log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));
       return new ArrayList<>();
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -273,7 +273,7 @@ public class SampleService {
           .collect(Collectors.toList());
     } catch (UnknownSampleSummaryException e) {
       log.error("unable to find sample summary", kv("sampleSummaryId", sampleSummaryId));
-      return new ArrayList<>();
+      return Collections.EMPTY_LIST;
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryActivationException.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryActivationException.java
@@ -1,3 +1,11 @@
 package uk.gov.ons.ctp.response.sample.service;
 
-public class SampleSummaryActivationException extends Exception {}
+public class SampleSummaryActivationException extends Exception {
+  public SampleSummaryActivationException() {
+    super();
+  }
+
+  public SampleSummaryActivationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/state/SampleSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/state/SampleSvcStateTransitionManagerFactory.java
@@ -49,8 +49,11 @@ public class SampleSvcStateTransitionManagerFactory implements StateTransitionMa
 
     Map<SampleEvent, SampleState> transitionMapForSampledInit = new HashMap<>();
     transitionMapForSampledInit.put(SampleEvent.ACTIVATED, SampleState.ACTIVE);
-    transitionMapForSampledInit.put(SampleEvent.FAIL_VALIDATION, SampleState.FAILED);
     transitions.put(SampleState.INIT, transitionMapForSampledInit);
+
+    Map<SampleEvent, SampleState> transitionMapForSampledActived = new HashMap<>();
+    transitionMapForSampledActived.put(SampleEvent.FAIL_VALIDATION, SampleState.FAILED);
+    transitions.put(SampleState.ACTIVE, transitionMapForSampledInit);
 
     StateTransitionManager<SampleState, SampleEvent> stateTransitionManager =
         new BasicStateTransitionManager<>(transitions);
@@ -68,6 +71,7 @@ public class SampleSvcStateTransitionManagerFactory implements StateTransitionMa
 
     Map<SampleUnitEvent, SampleUnitState> transitionMapForSampledPersisted = new HashMap<>();
     transitionMapForSampledPersisted.put(SampleUnitEvent.DELIVERING, SampleUnitState.DELIVERED);
+    transitionMapForSampledPersisted.put(SampleUnitEvent.FAIL_VALIDATION, SampleUnitState.FAILED);
     transitions.put(SampleUnitState.PERSISTED, transitionMapForSampledPersisted);
 
     Map<SampleUnitEvent, SampleUnitState> transitionMapForSampledInit = new HashMap<>();

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/state/SampleSvcStateTransitionManagerFactory.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/state/SampleSvcStateTransitionManagerFactory.java
@@ -53,7 +53,7 @@ public class SampleSvcStateTransitionManagerFactory implements StateTransitionMa
 
     Map<SampleEvent, SampleState> transitionMapForSampledActived = new HashMap<>();
     transitionMapForSampledActived.put(SampleEvent.FAIL_VALIDATION, SampleState.FAILED);
-    transitions.put(SampleState.ACTIVE, transitionMapForSampledInit);
+    transitions.put(SampleState.ACTIVE, transitionMapForSampledActived);
 
     StateTransitionManager<SampleState, SampleEvent> stateTransitionManager =
         new BasicStateTransitionManager<>(transitions);

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -4,10 +4,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -323,5 +322,47 @@ public class SampleServiceTest {
         .thenReturn(null);
     sampleService.findSampleUnitBySampleSummaryAndSampleUnitRef(
         newSummary.getId(), businessSampleUnit.getSampleUnitRef());
+  }
+
+  @Test
+  public void findSampleUnitsBySampleSummaryAndState() {
+    SampleSummary newSummary = createSampleSummary(5, 2);
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
+
+    SampleUnit sampleUnit = new SampleUnit();
+    sampleUnit.setId(UUID.randomUUID());
+    String sampleUnitRef = "11111111";
+    sampleUnit.setSampleUnitRef(sampleUnitRef);
+    sampleUnit.setSampleUnitType("B");
+    sampleUnit.setState(SampleUnitState.FAILED);
+
+    List<SampleUnit> sampleUnits = new ArrayList<>();
+    sampleUnits.add(sampleUnit);
+
+    when(sampleUnitRepository.findBySampleSummaryFKAndState(
+            newSummary.getSampleSummaryPK(), SampleUnitState.FAILED))
+        .thenReturn(sampleUnits.stream());
+
+    List<SampleUnit> su =
+        sampleService.findSampleUnitsBySampleSummaryAndState(
+            newSummary.getId(), SampleUnitState.FAILED);
+
+    assertEquals(sampleUnit, su.get(0));
+
+    verify(sampleUnitRepository, times(1))
+        .findBySampleSummaryFKAndState(newSummary.getSampleSummaryPK(), SampleUnitState.FAILED);
+  }
+
+  @Test
+  public void findSampleUnitsBySampleSummaryAndStateReturnsEmptyList() {
+
+    when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.ofNullable(null));
+
+    List<SampleUnit> su =
+        sampleService.findSampleUnitsBySampleSummaryAndState(
+            UUID.randomUUID(), SampleUnitState.FAILED);
+    assertTrue(su.isEmpty());
+
+    verify(sampleUnitRepository, never()).findBySampleSummaryFKAndState(any(), any());
   }
 }


### PR DESCRIPTION
# What and why?
If a sample file fails to activate then the sample summary should be moved to a failed state and the samples that have caused the failure should also be marked as failed.

The endpoint to request sample units for sample summary has also been modified to allow a parameter to be passed to retrieve samples of a specific state. This will allow collection exercise to retrieve the failed samples and determine why they are an issue, the result of which will eventually be displayed to a user.

# How to test?
1. Deploy to your env
1. load a sample file which will failed (i.e. an invalid form type)

# Trello
https://trello.com/c/Q5mkQDUb/900-bug-return-sample-unit-validation-errors-to-ce