### PR TITLE
Remove excessive logging about cache evictions

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.15
+version: 12.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.15
+appVersion: 12.1.16

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.14
+version: 12.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.14
+appVersion: 12.1.15

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -240,11 +240,13 @@ public class SampleSvcApplication {
       cacheNames = {COLLECTION_INSTRUMENT_CACHE})
   @Scheduled(fixedDelay = 60000)
   public void cacheEvict() {
-    /* This is getting rid of the cached entries in case anything's been changed. We imagine
-     * that the maximum of a 1 minute delay to seeing changes reflected in the collection
+    /*
+     * This is getting rid of the cached entries in case anything's been changed. We
+     * imagine
+     * that the maximum of a 1 minute delay to seeing changes reflected in the
+     * collection
      * instrument service will not cause any issues
      *
      */
-    log.debug("Collection instrument cache evicted");
   }
 }


### PR DESCRIPTION
# What and why?
This spams our logs and adds nothing

# How to test?

# Trello
https://trello.com/c/JirTzMVG/1242-clean-up-excessive-logging-of-collection-instrument-cache-evicted