### PR TITLE
move dockerfile into _infra folder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }} -f _infra/docker/Dockerfile .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM openjdk:11-jre-slim
-
-RUN apt-get update
-COPY target/samplesvc.jar /opt/samplesvc.jar
-
-ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/samplesvc.jar" ]

--- a/_infra/docker/Dockerfile
+++ b/_infra/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM openjdk:11-jre-slim
 
-COPY samplesvc.jar /opt/samplesvc.jar
+RUN apt-get update
+COPY target/samplesvc.jar /opt/samplesvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/samplesvc.jar" ]


### PR DESCRIPTION
# What and why?
The dockerfile for Java repos needed to be moved from the root to the _infra/docker folder so that it's like the Python repos. For some reason, this repo had two Dockerfiles (one in root, the other in infra), with the github workflow pointing at the root one. For that reason, I copied over the root dockerfile into the infra one and then deleted the root one.

# Trello
[Card](https://trello.com/c/lt82nJM8)