### PR TITLE
Edit timeouts in helm chart

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.20
+version: 12.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.20
+appVersion: 12.1.21

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -89,10 +89,10 @@ spec:
               path: /actuator/info
               port: {{ .Values.container.port }}
             initialDelaySeconds: 300
-            periodSeconds: 20
+            periodSeconds: 25
             failureThreshold: 5
             successThreshold: 1
-            timeoutSeconds: 5
+            timeoutSeconds: 8
           env:
           - name: DB_HOST
             {{- if .Values.database.managedPostgres }}


### PR DESCRIPTION
# What and why?

During a sample load, the app can be unresponsive to healthchecks even though nothing is wrong.  This change just gives the app a little more time to reply and checks slightly less frequently so that k8s is less likely to kill a pod that's just busy rather then unhealthy.

# How to test?

# Trello
