### PR TITLE
Add endpoint for sample summary status change

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ becoming cases.
 ### Sample and Sample summary creation
 - Sample summary is created with the INIT state
 - samples are individually set up against a sample summary (in the INIT state?)
+- Response-operations-ui (or any service) hits the endpoint to check if all sample units have been loaded.  If so, move
+  sample summary to ACTIVE state
 
 ### Sending samples to case for case creation
 - Listens on the <topic> for a sample activation message
@@ -73,7 +75,8 @@ to
 ## Quick guide
 
 - Sample Unit: A single row within the sample file
-- Sample Summary: The entire collection of Sample Units in a sample file (Counting unique refs only, duplicates are discarded, only the first is kept)
+- Sample Summary: The entire collection of Sample Units in a sample file (Counting unique refs only, duplicates are
+  discarded, only the first is kept)
 
 
 ## Copyright

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.21
+version: 12.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.21
+appVersion: 12.1.22

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.22
+version: 12.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.22
+appVersion: 12.2.0

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.2.0
+version: 13.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.2.0
+appVersion: 13.0.0

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 12.1.20
+version: 12.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.1.20
+appVersion: 12.1.21

--- a/diagrams/ingest-sequence.puml
+++ b/diagrams/ingest-sequence.puml
@@ -10,5 +10,6 @@ CSVWorker -> Sample: Create sample with INIT state
 Sample -> Sample : update Sample Unit to PERSISTED
 CSVWorker -> Party: Create party and attribute
 end
+ResponseOpsUI -> Sample: check all units have been loaded
 Sample -> Sample: update Sample Summary state to ACTIVE
 @enduml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -122,6 +122,10 @@ paths:
                 $ref: '#/components/schemas/SampleSummaryLoadingStatus'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          description: '#/components/responses/ServerError'
     delete:
       summary: Delete sample summary
       description: Delete sample summary and all sample units relating to it
@@ -302,7 +306,7 @@ components:
     InvalidRequestBodyError:
       description: One or more of the fields provided in the RequestBody wasn't part of the schema, wasn't set to a valid value, or the ID provided wasn't a proper UUID.
     ServerError:
-      description: SOmething unexpected happened with the server.
+      description: Something unexpected happened with the server.
   schemas:
     SampleUnit:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -99,7 +99,7 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           $ref: '#/components/responses/NotFoundError'
-  /samples/samplesummary/{sampleSummaryId}/check-all-units-present:
+  /samples/samplesummary/{sampleSummaryId}/check-and-transition-sample-summary-status:
     get:
       summary: Check all sample units present for the sample summary
       description: Checks all present and move to ACTIVE state if true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -99,6 +99,41 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           $ref: '#/components/responses/NotFoundError'
+  /samples/samplesummary/{sampleSummaryId}/check-all-units-present:
+    get:
+      summary: Check all sample units present for the sample summary
+      description: Checks all present and move to ACTIVE state if true
+      tags:
+        - samples
+      parameters:
+        - in: path
+          name: sampleSummaryId
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 34597808-ec88-4e93-af2f-228e33ff7946
+      responses:
+        '200':
+          description: The call was successful.  Will return this regardless of whether or not it's ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SampleSummaryLoadingStatus'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+    delete:
+      summary: Delete sample summary
+      description: Delete sample summary and all sample units relating to it
+      tags:
+        - samples
+      responses:
+        '204':
+          description: Sample summary and sample units were deleted successfully.
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
   /samples/samplesummary:
     post:
       summary: Create sample summary
@@ -334,5 +369,17 @@ components:
         totalSampleUnits:
           type: integer
           example: 1
+    SampleSummaryLoadingStatus:
+      type: object
+      properties:
+        areAllSampleUnitsLoaded:
+          type: boolean
+          example: true
+        expectedTotal:
+          type: integer
+          example: 200
+        currentTotal:
+          type: integer
+          example: 150
 security:
   - basicAuth: []

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -272,7 +272,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   }
 
   @RequestMapping(
-      value = "/samplesummary/{sampleSummaryId}/check-all-units-present",
+      value = "/samplesummary/{sampleSummaryId}/check-and-transition-sample-summary-status",
       method = RequestMethod.GET)
   public ResponseEntity<SampleSummaryLoadingStatus> checkAllSampleUnitsForSampleSummary(
       @PathVariable("sampleSummaryId") final UUID sampleSummaryId) {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -277,7 +277,8 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       @PathVariable("sampleSummaryId") final UUID sampleSummaryId) {
 
     try {
-      SampleSummaryLoadingStatus sampleSummaryLoadingStatus = sampleService.sampleSummaryStateCheck(sampleSummaryId);
+      SampleSummaryLoadingStatus sampleSummaryLoadingStatus =
+          sampleService.sampleSummaryStateCheck(sampleSummaryId);
       return ResponseEntity.ok(sampleSummaryLoadingStatus);
     } catch (CTPException | RuntimeException e) {
       log.error("unexpected exception", kv("sampleSummaryId", sampleSummaryId), e);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -30,10 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
-import uk.gov.ons.ctp.response.sample.representation.BusinessSampleUnitDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleSummaryDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
-import uk.gov.ons.ctp.response.sample.representation.SampleUnitsRequestDTO;
+import uk.gov.ons.ctp.response.sample.representation.*;
 import uk.gov.ons.ctp.response.sample.service.SampleService;
 import uk.gov.ons.ctp.response.sample.service.UnknownSampleSummaryException;
 import uk.gov.ons.ctp.response.sample.service.UnknownSampleUnitException;
@@ -276,12 +273,12 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   @RequestMapping(
       value = "/samplesummary/{sampleSummaryId}/check-all-units-present",
       method = RequestMethod.GET)
-  public ResponseEntity<Boolean> checkAllSampleUnitsForSampleSummary(
+  public ResponseEntity<SampleSummaryLoadingStatus> checkAllSampleUnitsForSampleSummary(
       @PathVariable("sampleSummaryId") final UUID sampleSummaryId) {
 
     try {
-      Boolean isAllPresent = sampleService.sampleSummaryStateCheck(sampleSummaryId);
-      return ResponseEntity.ok(isAllPresent);
+      SampleSummaryLoadingStatus sampleSummaryLoadingStatus = sampleService.sampleSummaryStateCheck(sampleSummaryId);
+      return ResponseEntity.ok(sampleSummaryLoadingStatus);
     } catch (CTPException | RuntimeException e) {
       log.error("unexpected exception", kv("sampleSummaryId", sampleSummaryId), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -273,22 +273,12 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     }
   }
 
-  @RequestMapping(value = "{sampleSummaryId}/check-all-units-present", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/samplesummary/{sampleSummaryId}/check-all-units-present",
+      method = RequestMethod.GET)
   public ResponseEntity<Boolean> checkAllSampleUnitsForSampleSummary(
-      @PathVariable("sampleSummaryId") final UUID sampleSummaryId,
-      final @Valid @RequestBody BusinessSampleUnitDTO businessSampleUnitDTO,
-      BindingResult bindingResult)
-      throws InvalidRequestException {
+      @PathVariable("sampleSummaryId") final UUID sampleSummaryId) {
 
-    if (bindingResult.hasErrors()) {
-      throw new InvalidRequestException("Binding errors for create action: ", bindingResult);
-    }
-    log.debug(
-        "create sample unit request received", kv("businessSampleUnitDTO", businessSampleUnitDTO));
-    BusinessSampleUnit businessSampleUnit =
-        mapperFacade.map(businessSampleUnitDTO, BusinessSampleUnit.class);
-
-    log.debug("business sample constructed", kv("businessSample", businessSampleUnit));
     try {
       Boolean isAllPresent = sampleService.sampleSummaryStateCheck(sampleSummaryId);
       return ResponseEntity.ok(isAllPresent);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -5,6 +5,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 import com.opencsv.bean.CsvToBean;
 import java.net.URI;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -275,14 +276,16 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
       method = RequestMethod.GET)
   public ResponseEntity<SampleSummaryLoadingStatus> checkAllSampleUnitsForSampleSummary(
       @PathVariable("sampleSummaryId") final UUID sampleSummaryId) {
-
     try {
       SampleSummaryLoadingStatus sampleSummaryLoadingStatus =
           sampleService.sampleSummaryStateCheck(sampleSummaryId);
       return ResponseEntity.ok(sampleSummaryLoadingStatus);
-    } catch (CTPException | RuntimeException e) {
+    } catch (CTPException e) {
       log.error("unexpected exception", kv("sampleSummaryId", sampleSummaryId), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    } catch (NoSuchElementException e) {
+      log.error("Sample summary not found", kv("sampleSummaryId", sampleSummaryId), e);
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleSummaryLoadingStatus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleSummaryLoadingStatus.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.response.sample.representation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleSummaryLoadingStatus {
+  private boolean areAllSampleUnitsLoaded;
+  private Integer expectedTotal;
+  private Integer currentTotal;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -195,7 +195,8 @@ public class SampleService {
    * @throws CTPException
    */
   @Transactional(propagation = Propagation.REQUIRED)
-  public SampleSummaryLoadingStatus sampleSummaryStateCheck(UUID sampleSummaryId) throws CTPException {
+  public SampleSummaryLoadingStatus sampleSummaryStateCheck(UUID sampleSummaryId)
+      throws CTPException {
     SampleSummary sampleSummary = sampleSummaryRepository.findById(sampleSummaryId).orElseThrow();
     Integer sampleSummaryPK = sampleSummary.getSampleSummaryPK();
     int created =

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -164,7 +164,6 @@ public class SampleEndpointUnitTest {
   @Test
   public void checkAllSampleUnitsForSampleSummaryNotFound() throws Exception {
     when(sampleService.sampleSummaryStateCheck(any())).thenThrow(new NoSuchElementException());
-    // when(sampleService.findSampleSummary(any())).thenReturn(null);
 
     String url =
         String.format("/samples/samplesummary/%s/check-all-units-present", UUID.randomUUID());

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -166,7 +166,9 @@ public class SampleEndpointUnitTest {
     when(sampleService.sampleSummaryStateCheck(any())).thenThrow(new NoSuchElementException());
 
     String url =
-        String.format("/samples/samplesummary/%s/check-and-transition-sample-summary-status", UUID.randomUUID());
+        String.format(
+            "/samples/samplesummary/%s/check-and-transition-sample-summary-status",
+            UUID.randomUUID());
 
     ResultActions actions = mockMvc.perform(get(url));
 

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import libs.common.error.RestExceptionHandler;
 import libs.common.jackson.CustomObjectMapper;
@@ -158,5 +159,18 @@ public class SampleEndpointUnitTest {
     dto.setExpectedCollectionInstruments(1);
 
     verify(sampleService, times(1)).createAndSaveSampleSummary(dto);
+  }
+
+  @Test
+  public void checkAllSampleUnitsForSampleSummaryNotFound() throws Exception {
+    when(sampleService.sampleSummaryStateCheck(any())).thenThrow(new NoSuchElementException());
+    // when(sampleService.findSampleSummary(any())).thenReturn(null);
+
+    String url =
+        String.format("/samples/samplesummary/%s/check-all-units-present", UUID.randomUUID());
+
+    ResultActions actions = mockMvc.perform(get(url));
+
+    actions.andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpointUnitTest.java
@@ -166,7 +166,7 @@ public class SampleEndpointUnitTest {
     when(sampleService.sampleSummaryStateCheck(any())).thenThrow(new NoSuchElementException());
 
     String url =
-        String.format("/samples/samplesummary/%s/check-all-units-present", UUID.randomUUID());
+        String.format("/samples/samplesummary/%s/check-and-transition-sample-summary-status", UUID.randomUUID());
 
     ResultActions actions = mockMvc.perform(get(url));
 


### PR DESCRIPTION
# What and why?

Prior to this PR, loading a sample meant the sample service would hit the database once to load the sample unit, then again to get the count of all the sample units to see if it was done yet.  If it wasn't then it'd not do anything else, if all the sample units had been loaded then it would transition the state of the sample summary to ACTIVE (which let the things that cared know that the sample load was complete).

This new PR changes that.  During the sample load it does the 1 call per unit that the current one does to save it to the database, but now there is a separate http endpoint that needs to be called to check if all the sample units for a sample summary have been loaded, and then change the status. 
Doing it this way results in much much less strain on the database as getting the count was a very expensive operation and would put the database load at or near 100% during sample loads.  It should hopefully result in samples being loaded faster, though we'd need to do some testing around that to see if that's the case.

This PR (https://github.com/ONSdigital/response-operations-ui/pull/765) needs to be in at the same time as they come as a pair.

# How to test?

- Deploy both PRs to your enviornment
- Create a collection exercise and load a large-ish (between 1k-5k) sample. While it's loading the state should stay as INIT and you should see calls in response-ops hitting the new check endpoint.
- Once they're all loaded, you should see the check endpoint transition the state of the sample summary to ACTIVE.
- Once the state is active, response-ops shouldn't hit that endpoint anymore until you delete the sample.
- Also test deleting the sample and adding it again, the calls should resume.
- Set the exercise live.  Everything should be the same and there should be no more calls to this new endpoint.

# Trello
