### PR TITLE
RAS-638 Investigate how "Ready for live" button works, when replacing sample file (track time)

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.12
+version: 13.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.12
+appVersion: 13.0.13

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -168,17 +168,17 @@ spec:
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_HOST
-            { { - if .Values.dns.enabled } }
+            {{- if .Values.dns.enabled }}
             value: "collection-exercise.{{ .Values.namespace }}.svc.cluster.local"
-            { { - else } }
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_HOST)"
-            { { - end } }
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PORT
-            { { - if .Values.dns.enabled } }
+            {{- if .Values.dns.enabled }}
             value: "{{ .Values.dns.wellKnownPort }}"
-            { { - else } }
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_PORT)"
-            { { - end } }
+            {{- end }}
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_USERNAME
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PASSWORD

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -167,6 +167,22 @@ spec:
             value: "$(SECURITY_USER_NAME)"
           - name: COLLECTION_INSTRUMENT_SVC_CONNECTION_CONFIG_PASSWORD
             value: "$(SECURITY_USER_PASSWORD)"
+          - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_HOST
+            { { - if .Values.dns.enabled } }
+            value: "collection-exercise.{{ .Values.namespace }}.svc.cluster.local"
+            { { - else } }
+            value: "$(COLLECTION_EXERCISE_SERVICE_HOST)"
+            { { - end } }
+          - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PORT
+            { { - if .Values.dns.enabled } }
+            value: "{{ .Values.dns.wellKnownPort }}"
+            { { - else } }
+            value: "$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            { { - end } }
+          - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_USERNAME
+            value: "$(SECURITY_USER_NAME)"
+          - name: COLLECTION_EXERCISE_SVC_CONNECTION_CONFIG_PASSWORD
+            value: "$(SECURITY_USER_PASSWORD)"
           - name: PARTY_SVC_CONNECTION_CONFIG_HOST
             {{- if .Values.dns.enabled }}
             value: "party.{{ .Values.namespace }}.svc.cluster.local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,17 @@ services:
       - DATABASE_URI=postgresql://postgres:postgres@postgres-it:5432/postgres
       - SECURITY_USER_NAME=admin
       - SECURITY_USER_PASSWORD=secret
+  collection-exercise-service:
+    container_name: collection-exercise-it
+    image: sdcplatform/collectionexercisesvc
+    external_links:
+      - postgres-it
+    ports:
+      - "38145:8145"
+    environment:
+      - DATABASE_URI=postgresql://postgres:postgres@postgres-it:5432/postgres
+      - SECURITY_USER_NAME=admin
+      - SECURITY_USER_PASSWORD=secret
   pubsub-emulator:
     container_name: pubsub-emulator-it
     image: eu.gcr.io/ons-rasrmbs-management/pubsub-emulator

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -52,8 +52,6 @@ public class CollectionExerciseSvcClient {
     sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
     HttpEntity<SampleReadinessRequestDTO> httpEntity =
         restUtility.createHttpEntity(sampleReadinessNotificationDTO);
-    System.out.println(uriComponents);
-    System.out.println(httpEntity);
     restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -1,0 +1,56 @@
+package uk.gov.ons.ctp.response.client;
+
+import libs.common.rest.RestUtility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import uk.gov.ons.ctp.response.sample.config.AppConfig;
+import uk.gov.ons.ctp.response.sample.representation.SampleReadinessRequestDTO;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+@Component
+public class CollectionExerciseSvcClient {
+    private static final Logger log = LoggerFactory.getLogger(CollectionExerciseSvcClient.class);
+
+    private AppConfig appConfig;
+    private RestTemplate restTemplate;
+    private RestUtility restUtility;
+
+    public CollectionExerciseSvcClient(
+            AppConfig appConfig,
+            RestTemplate restTemplate,
+            @Qualifier("collectionExerciseRestUtility") RestUtility restUtility) {
+        this.appConfig = appConfig;
+        this.restTemplate = restTemplate;
+        this.restUtility = restUtility;
+    }
+
+    @Retryable(
+            value = {RestClientException.class},
+            maxAttemptsExpression = "#{${retries.maxAttempts}}",
+            backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
+    public void collectionExerciseSampleReadinessRequest(String sampleSummaryId,String collectionExerciseId) {
+        log.debug(
+                "Notifying Collection Exercise of sample readiness {}",
+                kv("collection_exercise_id", collectionExerciseId));
+        UriComponents uriComponents =
+                restUtility.createUriComponents(
+                        appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
+                        null, collectionExerciseId);
+        SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
+        sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
+        HttpEntity<SampleReadinessRequestDTO> httpEntity = restUtility.createHttpEntity(sampleReadinessNotificationDTO);
+        System.out.println(uriComponents);
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
+    }
+
+}

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.response.client;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
+import java.util.UUID;
 import libs.common.rest.RestUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import org.springframework.web.util.UriComponents;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.representation.SampleReadinessRequestDTO;
 
+/** HTTP RestClient implementation for calls to the Collection Exercise service. */
 @Component
 public class CollectionExerciseSvcClient {
   private static final Logger log = LoggerFactory.getLogger(CollectionExerciseSvcClient.class);
@@ -38,18 +40,18 @@ public class CollectionExerciseSvcClient {
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-  public void collectionExerciseSampleReadinessRequest(
-      String sampleSummaryId, String collectionExerciseId) {
+  public void collectionExerciseSampleSummaryReadiness(
+      UUID sampleSummaryId, UUID collectionExerciseId) {
     log.debug(
         "Notifying Collection Exercise of sample readiness {}",
         kv("collection_exercise_id", collectionExerciseId));
     UriComponents uriComponents =
         restUtility.createUriComponents(
             appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
-            null,
-            collectionExerciseId);
+            null);
     SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
     sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
+    sampleReadinessNotificationDTO.setCollectionExerciseId(collectionExerciseId);
     HttpEntity<SampleReadinessRequestDTO> httpEntity =
         restUtility.createHttpEntity(sampleReadinessNotificationDTO);
     System.out.println(uriComponents);

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.client;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import libs.common.rest.RestUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,42 +17,42 @@ import org.springframework.web.util.UriComponents;
 import uk.gov.ons.ctp.response.sample.config.AppConfig;
 import uk.gov.ons.ctp.response.sample.representation.SampleReadinessRequestDTO;
 
-import static net.logstash.logback.argument.StructuredArguments.kv;
-
 @Component
 public class CollectionExerciseSvcClient {
-    private static final Logger log = LoggerFactory.getLogger(CollectionExerciseSvcClient.class);
+  private static final Logger log = LoggerFactory.getLogger(CollectionExerciseSvcClient.class);
 
-    private AppConfig appConfig;
-    private RestTemplate restTemplate;
-    private RestUtility restUtility;
+  private AppConfig appConfig;
+  private RestTemplate restTemplate;
+  private RestUtility restUtility;
 
-    public CollectionExerciseSvcClient(
-            AppConfig appConfig,
-            RestTemplate restTemplate,
-            @Qualifier("collectionExerciseRestUtility") RestUtility restUtility) {
-        this.appConfig = appConfig;
-        this.restTemplate = restTemplate;
-        this.restUtility = restUtility;
-    }
+  public CollectionExerciseSvcClient(
+      AppConfig appConfig,
+      RestTemplate restTemplate,
+      @Qualifier("collectionExerciseRestUtility") RestUtility restUtility) {
+    this.appConfig = appConfig;
+    this.restTemplate = restTemplate;
+    this.restUtility = restUtility;
+  }
 
-    @Retryable(
-            value = {RestClientException.class},
-            maxAttemptsExpression = "#{${retries.maxAttempts}}",
-            backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-    public void collectionExerciseSampleReadinessRequest(String sampleSummaryId,String collectionExerciseId) {
-        log.debug(
-                "Notifying Collection Exercise of sample readiness {}",
-                kv("collection_exercise_id", collectionExerciseId));
-        UriComponents uriComponents =
-                restUtility.createUriComponents(
-                        appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
-                        null, collectionExerciseId);
-        SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
-        sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
-        HttpEntity<SampleReadinessRequestDTO> httpEntity = restUtility.createHttpEntity(sampleReadinessNotificationDTO);
-        System.out.println(uriComponents);
-        restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
-    }
-
+  @Retryable(
+      value = {RestClientException.class},
+      maxAttemptsExpression = "#{${retries.maxAttempts}}",
+      backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
+  public void collectionExerciseSampleReadinessRequest(
+      String sampleSummaryId, String collectionExerciseId) {
+    log.debug(
+        "Notifying Collection Exercise of sample readiness {}",
+        kv("collection_exercise_id", collectionExerciseId));
+    UriComponents uriComponents =
+        restUtility.createUriComponents(
+            appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
+            null,
+            collectionExerciseId);
+    SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
+    sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
+    HttpEntity<SampleReadinessRequestDTO> httpEntity =
+        restUtility.createHttpEntity(sampleReadinessNotificationDTO);
+    System.out.println(uriComponents);
+    restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -46,13 +46,14 @@ public class CollectionExerciseSvcClient {
         kv("sample_summary_id", sampleSummaryId));
     UriComponents uriComponents =
         restUtility.createUriComponents(
-            appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
+            appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleSummaryReadiness(),
             null);
     SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
     sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
     HttpEntity<SampleReadinessRequestDTO> httpEntity =
         restUtility.createHttpEntity(sampleReadinessNotificationDTO);
     System.out.println(uriComponents);
+    System.out.println(httpEntity);
     restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -40,18 +40,16 @@ public class CollectionExerciseSvcClient {
       value = {RestClientException.class},
       maxAttemptsExpression = "#{${retries.maxAttempts}}",
       backoff = @Backoff(delayExpression = "#{${retries.backoff}}"))
-  public void collectionExerciseSampleSummaryReadiness(
-      UUID sampleSummaryId, UUID collectionExerciseId) {
+  public void collectionExerciseSampleSummaryReadiness(UUID sampleSummaryId) {
     log.debug(
         "Notifying Collection Exercise of sample readiness {}",
-        kv("collection_exercise_id", collectionExerciseId));
+        kv("sample_summary_id", sampleSummaryId));
     UriComponents uriComponents =
         restUtility.createUriComponents(
             appConfig.getCollectionExerciseSvc().getCollectionExerciseSampleReadinessRequest(),
             null);
     SampleReadinessRequestDTO sampleReadinessNotificationDTO = new SampleReadinessRequestDTO();
     sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
-    sampleReadinessNotificationDTO.setCollectionExerciseId(collectionExerciseId);
     HttpEntity<SampleReadinessRequestDTO> httpEntity =
         restUtility.createHttpEntity(sampleReadinessNotificationDTO);
     System.out.println(uriComponents);

--- a/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
+++ b/src/main/java/uk/gov/ons/ctp/response/client/CollectionExerciseSvcClient.java
@@ -52,6 +52,8 @@ public class CollectionExerciseSvcClient {
     sampleReadinessNotificationDTO.setSampleSummaryId(sampleSummaryId);
     HttpEntity<SampleReadinessRequestDTO> httpEntity =
         restUtility.createHttpEntity(sampleReadinessNotificationDTO);
+    System.out.println(uriComponents);
+    System.out.println(httpEntity);
     restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -193,6 +193,17 @@ public class SampleSvcApplication {
   }
 
   /**
+   * The RestUtility bean for the CollectionExercise service
+   *
+   * @return the RestUtility bean for the CollectionExercise service
+   */
+  @Bean
+  @Qualifier("collectionExerciseRestUtility")
+  public RestUtility collectionExerciseRestUtility(){
+    return new RestUtility(appConfig.getCollectionExerciseSvc().getConnectionConfig());
+  }
+
+  /**
    * The RestUtility bean for the Survey service
    *
    * @return the RestUtility bean for the Survey service

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -199,7 +199,7 @@ public class SampleSvcApplication {
    */
   @Bean
   @Qualifier("collectionExerciseRestUtility")
-  public RestUtility collectionExerciseRestUtility(){
+  public RestUtility collectionExerciseRestUtility() {
     return new RestUtility(appConfig.getCollectionExerciseSvc().getConnectionConfig());
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/AppConfig.java
@@ -17,6 +17,7 @@ public class AppConfig {
   private PartySvc partySvc;
   private CollectionInstrumentSvc collectionInstrumentSvc;
   private SurveySvc surveySvc;
+  private CollectionExerciseSvc collectionExerciseSvc;
   private Logging logging;
   private GCP gcp;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.response.sample.config;
+
+import libs.common.rest.RestUtilityConfig;
+import lombok.Data;
+import net.sourceforge.cobertura.CoverageIgnore;
+
+/**
+ * App config POJO for CollectionInstrument service access - host/location and endpoint locations
+ */
+@CoverageIgnore
+@Data
+public class CollectionExerciseSvc {
+    private RestUtilityConfig connectionConfig;
+    private String collectionExerciseSampleReadinessRequest;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
@@ -10,6 +10,6 @@ import net.sourceforge.cobertura.CoverageIgnore;
 @CoverageIgnore
 @Data
 public class CollectionExerciseSvc {
-    private RestUtilityConfig connectionConfig;
-    private String collectionExerciseSampleReadinessRequest;
+  private RestUtilityConfig connectionConfig;
+  private String collectionExerciseSampleReadinessRequest;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
@@ -4,9 +4,7 @@ import libs.common.rest.RestUtilityConfig;
 import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 
-/**
- * App config POJO for CollectionInstrument service access - host/location and endpoint locations
- */
+/** App config POJO for CollectionExercise service access - host/location and endpoint locations */
 @CoverageIgnore
 @Data
 public class CollectionExerciseSvc {

--- a/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/config/CollectionExerciseSvc.java
@@ -9,5 +9,5 @@ import net.sourceforge.cobertura.CoverageIgnore;
 @Data
 public class CollectionExerciseSvc {
   private RestUtilityConfig connectionConfig;
-  private String collectionExerciseSampleReadinessRequest;
+  private String collectionExerciseSampleSummaryReadiness;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/endpoint/SampleEndpoint.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.ctp.response.client.CollectionExerciseSvcClient;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.representation.*;
@@ -51,6 +52,8 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
   public SampleEndpoint(SampleService sampleService) {
     this.sampleService = sampleService;
   }
+
+  @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   /**
    * GET endpoint for retrieving a list of all existing SampleSummaries
@@ -275,6 +278,7 @@ public final class SampleEndpoint extends CsvToBean<BusinessSampleUnit> {
     try {
       SampleSummaryLoadingStatus sampleSummaryLoadingStatus =
           sampleService.sampleSummaryStateCheck(sampleSummaryId);
+      collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(sampleSummaryId);
       return ResponseEntity.ok(sampleSummaryLoadingStatus);
     } catch (CTPException e) {
       log.error("unexpected exception", kv("sampleSummaryId", sampleSummaryId), e);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SampleReadinessRequestDTO {
-    String sampleSummaryId;
+  String sampleSummaryId;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.sample.representation;
 
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SampleReadinessRequestDTO {
-  String sampleSummaryId;
+  UUID sampleSummaryId;
+  UUID collectionExerciseId;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
@@ -11,5 +11,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class SampleReadinessRequestDTO {
   UUID sampleSummaryId;
-  UUID collectionExerciseId;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/representation/SampleReadinessRequestDTO.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.response.sample.representation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class SampleReadinessRequestDTO {
+    String sampleSummaryId;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -217,8 +217,8 @@ public class SampleService {
           kv("sampleSummaryPK", sampleSummaryPK));
       activateSampleSummaryState(sampleSummary);
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(true);
-      collectionExerciseSvcClient.collectionExerciseSampleReadinessRequest(
-          sampleSummaryId.toString(), sampleSummary.getCollectionExerciseId().toString());
+      collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(
+          sampleSummaryId, sampleSummary.getCollectionExerciseId());
     } else {
       log.info("Not all sample units have been loaded", kv("sampleSummaryPK", sampleSummaryPK));
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(false);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -217,8 +217,7 @@ public class SampleService {
           kv("sampleSummaryPK", sampleSummaryPK));
       activateSampleSummaryState(sampleSummary);
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(true);
-      collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(
-          sampleSummaryId, sampleSummary.getCollectionExerciseId());
+      collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(sampleSummaryId);
     } else {
       log.info("Not all sample units have been loaded", kv("sampleSummaryPK", sampleSummaryPK));
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(false);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.ctp.response.client.CollectionExerciseSvcClient;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
@@ -45,6 +46,8 @@ public class SampleService {
   @Qualifier("sampleUnitTransitionManager")
   private StateTransitionManager<SampleUnitState, SampleUnitEvent>
       sampleSvcUnitStateTransitionManager;
+
+  @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   public List<SampleSummary> findAllSampleSummaries() {
     return sampleSummaryRepository.findAll();
@@ -214,6 +217,8 @@ public class SampleService {
           kv("sampleSummaryPK", sampleSummaryPK));
       activateSampleSummaryState(sampleSummary);
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(true);
+      collectionExerciseSvcClient.collectionExerciseSampleReadinessRequest(
+              sampleSummaryId.toString(), sampleSummary.getCollectionExerciseId().toString());
     } else {
       log.info("Not all sample units have been loaded", kv("sampleSummaryPK", sampleSummaryPK));
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(false);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -218,7 +218,7 @@ public class SampleService {
       activateSampleSummaryState(sampleSummary);
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(true);
       collectionExerciseSvcClient.collectionExerciseSampleReadinessRequest(
-              sampleSummaryId.toString(), sampleSummary.getCollectionExerciseId().toString());
+          sampleSummaryId.toString(), sampleSummary.getCollectionExerciseId().toString());
     } else {
       log.info("Not all sample units have been loaded", kv("sampleSummaryPK", sampleSummaryPK));
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(false);

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleService.java
@@ -17,7 +17,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.ons.ctp.response.client.CollectionExerciseSvcClient;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
@@ -46,8 +45,6 @@ public class SampleService {
   @Qualifier("sampleUnitTransitionManager")
   private StateTransitionManager<SampleUnitState, SampleUnitEvent>
       sampleSvcUnitStateTransitionManager;
-
-  @Autowired private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   public List<SampleSummary> findAllSampleSummaries() {
     return sampleSummaryRepository.findAll();
@@ -217,7 +214,6 @@ public class SampleService {
           kv("sampleSummaryPK", sampleSummaryPK));
       activateSampleSummaryState(sampleSummary);
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(true);
-      collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(sampleSummaryId);
     } else {
       log.info("Not all sample units have been loaded", kv("sampleSummaryPK", sampleSummaryPK));
       sampleSummaryLoadingStatus.setAreAllSampleUnitsLoaded(false);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -18,6 +18,10 @@ party-svc:
   connection-config:
     port: 38081
 
+collection-exercise-svc:
+  connection-config:
+    port: 38145
+
 gcp:
   project: "test"
   caseNotificationTopic: "test_topic"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,6 +139,24 @@ party-svc:
     # time to read response
     read-timeout-milli-seconds: 5000
 
+
+collection-exercise-svc:
+  collection-exercise-sample-summary-readiness: /sample/summary-readiness
+  connection-config:
+    scheme: http
+    host: localhost
+    port: 8145
+    username: admin
+    password: secret
+    # how many times should we attempt connection on failure
+    retry-attempts: 5
+    # sleep between retries
+    retry-pause-milli-seconds: 5000
+    # time to estab connection
+    connect-timeout-milli-seconds: 5000
+    # time to read response
+    read-timeout-milli-seconds: 5000
+
 messaging:
   backoffInitial: 5000
   backoffMultiplier: 3

--- a/src/test/java/uk/gov/ons/ctp/response/sample/client/CollectionExerciseSvcClientTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/client/CollectionExerciseSvcClientTest.java
@@ -1,0 +1,55 @@
+package uk.gov.ons.ctp.response.sample.client;
+
+import static org.mockito.Mockito.*;
+
+import java.net.URI;
+import java.util.UUID;
+import libs.common.rest.RestUtility;
+import libs.common.rest.RestUtilityConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.ons.ctp.response.client.CollectionExerciseSvcClient;
+import uk.gov.ons.ctp.response.sample.config.AppConfig;
+import uk.gov.ons.ctp.response.sample.config.CollectionExerciseSvc;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollectionExerciseSvcClientTest {
+  @Spy private RestUtility restUtility = new RestUtility(RestUtilityConfig.builder().build());
+  @Mock private RestTemplate restTemplate;
+  @Mock private AppConfig appConfig;
+
+  @InjectMocks private CollectionExerciseSvcClient collectionExerciseSvcClient;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    CollectionExerciseSvc collectionExerciseSvc = new CollectionExerciseSvc();
+    when(appConfig.getCollectionExerciseSvc()).thenReturn(collectionExerciseSvc);
+  }
+
+  @Test
+  public void notifyCollectionExerciseOfSampleReadiness() {
+    // Given
+    UUID sampleSummaryId = UUID.randomUUID();
+    when(restTemplate.exchange(
+            any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(ResponseEntity.ok().build());
+
+    // When
+    collectionExerciseSvcClient.collectionExerciseSampleSummaryReadiness(sampleSummaryId);
+
+    // Then
+    verify(restTemplate, times(1))
+        .exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/sample/service/SampleServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ons.ctp.response.client.CollectionExerciseSvcClient;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleSummary;
 import uk.gov.ons.ctp.response.sample.domain.model.SampleUnit;
 import uk.gov.ons.ctp.response.sample.domain.repository.SampleSummaryRepository;
@@ -54,6 +55,8 @@ public class SampleServiceTest {
   @Mock
   private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent>
       sampleSvcUnitStateTransitionManager;
+
+  @Mock private CollectionExerciseSvcClient collectionExerciseSvcClient;
 
   @InjectMocks private SampleService sampleService;
 
@@ -132,6 +135,7 @@ public class SampleServiceTest {
   public void activateSampleSummaryTest() throws Exception {
     SampleSummary newSummary = createSampleSummary(1, 1);
     newSummary.setTotalSampleUnits(1);
+    newSummary.setCollectionExerciseId(UUID.randomUUID());
     when(sampleSummaryRepository.findById(any(UUID.class))).thenReturn(Optional.of(newSummary));
     when(sampleUnitRepository.countBySampleSummaryFKAndState(1, SampleUnitState.PERSISTED))
         .thenReturn(1);


### PR DESCRIPTION
# What and why?
This PR adds the configuration and request needed to let collection exercise know when the sample is ready and loaded so that when a sample is loaded in response operations, and all other values are loaded, the `Set Ready for live` button appears.
# How to test?
- Deploy this PR to your environment
  - Must be deployed using helm because there are changes to the deployment which are not reflected when deploying through spinnaker
  - Update the values.yaml file for your environment (including the gcp values)
  - Must be deployed last
- Deploy https://github.com/ONSdigital/rm-collection-exercise-service/pull/319 to your environment
- Deploy https://github.com/ONSdigital/response-operations-ui/pull/888 to your environment
- Set up a collection exercise in this order
   - Required event dates
   - A collection instrument
   - A sample file
- Ensure the sample has loaded
 - There is no `Refresh` link at the top of the page
- The `Set ready for live` button appears and the collection exercise
# Jira
[RAS-638](https://jira.ons.gov.uk/browse/RAS-638)