### PR TITLE
Update set-output to environment variables

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
@@ -62,16 +62,16 @@ jobs:
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
           echo "$PR"
-          echo "pr_number=pr-$PR" >> $GITHUB_OUTPUT
+          echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }} .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ steps.tag.outputs.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
@@ -80,7 +80,7 @@ jobs:
         id: vars
         run: |
           git fetch --tags
-          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: update versions
         if: github.ref != 'refs/heads/main'
         env:
@@ -89,19 +89,19 @@ jobs:
             auto patch increment
         shell: bash
         run: |
-          echo "Current git version: ${{ steps.vars.outputs.tag }}"
+          echo "Current git version: ${{ env.tag }}"
           export APP_VERSION=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
           export CHART_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
           echo "appVersion: $APP_VERSION"
           echo "chartVersion: $CHART_VERSION"
-          if [ ${{ steps.vars.outputs.tag }} = $APP_VERSION ]; then
+          if [ ${{ env.tag }} = $APP_VERSION ]; then
             echo "versions match, incrementing patch"
-            OLD_PATCH=$(echo ${{ steps.vars.outputs.tag }} | cut -d '.' -f3)
+            OLD_PATCH=$(echo ${{ env.tag }} | cut -d '.' -f3)
             echo "OLD patch: $OLD_PATCH"
             NEW_PATCH=$(($OLD_PATCH + 1))
             echo "New patch version: $NEW_PATCH"
-            NEW_APP_VERSION="appVersion: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
-            NEW_CHART_VERSION="version: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+            NEW_APP_VERSION="appVersion: $(echo ${{ env.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+            NEW_CHART_VERSION="version: $(echo ${{ env.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
             sed -i -e "s/appVersion: .*/$NEW_APP_VERSION/g" $CHART_DIRECTORY/Chart.yaml
             sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
             git config user.name "ras-rm-pr-bot"
@@ -139,7 +139,7 @@ jobs:
         id: release
         shell: bash
         run: |
-          echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_OUTPUT
+          echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_ENV
     
       - name: package helm
         run: |
@@ -150,17 +150,17 @@ jobs:
       - name: Publish dev Chart
         if: github.ref != 'refs/heads/main'
         run: |
-          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ steps.tag.outputs.pr_number }}.tgz
+          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
 
       - name: Publish Charts
@@ -174,11 +174,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.release.outputs.version }}
-          release_name: ${{ steps.release.outputs.version }}
+          tag_name: ${{ env.version }}
+          release_name: ${{ env.version }}
           body: |
             Automated release
-            ${{ steps.release.outputs.version }}
+            ${{ env.version }}
           draft: false
           prerelease: false
 

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.13
+version: 13.0.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.13
+appVersion: 13.0.14


### PR DESCRIPTION
# What and why?
This PR replaces set-output within the .github workflow file with environment variables to fix a deprecation with set-output. It also updates actions/auth to v2.

# How to test?
Check the github builds for any deprecation warnings and ensure the workflow works after the changes.

# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-915