### PR TITLE
Force retrieving the collection-instrument ID per formtype every time

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.15
+version: 13.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.15
+appVersion: 13.0.16

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryEnrichmentService.java
@@ -245,9 +245,9 @@ public class SampleSummaryEnrichmentService {
     }
 
     Optional<UUID> collectionInstrumentId =
-        formTypeMap.computeIfAbsent(
+        formTypeMap.compute(
             formType,
-            key -> {
+            (key, value) -> {
               UUID ciId = null;
               List<String> classifierTypes = requestSurveyClassifiers(surveyId);
               try {


### PR DESCRIPTION
# What and why?

**PR for demonstration purposes only**

To demonstrate that `RU_REF` classifiers are supported by the sample and collection instrument service, and to highlight the current behaviour as to why unique formtypes are required for `RU_REF` classifier surveys.

This hack updates the `findAndUpdateCollectionInstrument` method to force the request of a unit's collection instrument regardless of it's formtype.

The method currently tracks whether or not it will request the instrument ID against the different formtypes in the `formTypeMap`. This works ok surveys with formtype as the classifier, but not for surveys where `RU_REF` is the classifier.

The current work around for `RU_REF` classifier samples is for the business to give unique formtypes to each unit in the sample. This effectively forces the method to request the instrument ID each time, which it correctly does by `RU_REF` classifier against the instrument service. That bit works fine. 

The change in this PR simply uses the Map `compute` method over the `computeIfAbsent` method causing it to re-request even if its already done so for that formtype. This would allow the business to use a single formtype for survey that use `RU_REF` instead of `FORM_TYPE` as the classifier.

It's not the best solution, and would have the consequence of making redundant calls to the collection instrument service for the vast majority of samples. An alternative solution has been mentioned in the associated card.

------------------

`RU_REF` classifiers are indeed supported and defined, for example;
```
{
 "id":   "72a35a88-bbc3-4ae8-8b3b-bb3174c6166e",
 "name": "COLLECTION_INSTRUMENT",
 "classifierTypes": [
        "COLLECTION_EXERCISE",
        "RU_REF"]
 }
```
This allows collection instrument to be requested from the collection-instrument service by `ru_ref` during sample enrichment's `findAndUpdateCollectionInstrument()`

```
http://localhost:8002/collection-instrument-api/1.0.2/collectioninstrument?searchString={"RU_REF":"00000000001","COLLECTION_EXERCISE":"bfec5b9b-1a98-42dd-b486-d6ea298d0886","SURVEY_ID":"5c8d4ea7-143f-43cd-a3bd-1ec29561b363"}
```
However although the instruments are requested by ru_ref, the current implementation additionally hardcodes the classifier `formtype` as the unique attribute by which requests for the collection_instrument_id are tracked. This means when a given unit has its `collection_instrument_id` resolved, any subsequent sample unit with the same formtype will get the same `collection_instrument_id`. This works for surveys which have formtype as their classifier, but not were the collection instruments should be tracked against the ru_ref.

The reason is due to the hardcoded use of `formTypeMap` and `computeIfAbsent` which doesn't support non-formtype classifiers such as `ru_ref`. This appears to be deliberate and likely to be a consequence of having no other use cases other than unique form types during the original requirements.

One possible solution maybe to not hardcode a `formTypeMap`, but instead create a `classifierMap`, the keys of which are a concatenation of each classifier permutation. This would behave in a similar way to how the enrichments selects its collection instruments against the `formTypeMap`, but would be flexible and extensible.
