### PR TITLE
Migrate Spring cloud pubsub to google cloud pubsub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,12 @@ jobs:
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
 
+      - name: Publish Charts
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
+          gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
+
       - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - name: Configure GCR
         run: |
           gcloud auth configure-docker
@@ -163,24 +163,11 @@ jobs:
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }}
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
 
-      - name: Publish Charts
-        if: github.ref == 'refs/heads/main'
-        run: |
-          cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
-          gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
-
-      - uses: actions/create-release@v1
+      - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.16
+version: 13.0.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.16
+appVersion: 13.0.17

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</scm>
 	<properties>
 		<springboot.version>2.6.7</springboot.version>
-		<spring.cloud.gcp.version>1.2.8.RELEASE</spring.cloud.gcp.version>
+		<spring.cloud.gcp.version>3.7.8</spring.cloud.gcp.version>
 		<common.version>10.49.4</common.version>
 		<java.version>17</java.version>
 		<surefire.version>3.2.5</surefire.version>
@@ -25,15 +25,13 @@
 	<dependencies>
 		<!-- Spring Dependencies -->
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
+			<groupId>com.google.cloud</groupId>
 			<artifactId>spring-cloud-gcp-starter-pubsub</artifactId>
-			<version>1.2.8.RELEASE</version>
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
+			<groupId>com.google.cloud</groupId>
 			<artifactId>spring-cloud-gcp-pubsub</artifactId>
-			<version>1.2.8.RELEASE</version>
 		</dependency>
 
 		<dependency>
@@ -90,7 +88,6 @@
 			<artifactId>spring-security-crypto</artifactId>
 		</dependency>
 
-
 		<!-- Third Party -->
 		<!-- Added because of mockito errors. It's explained more here
 		https://dev.to/scottshipp/how-to-fix-a-mockito-cannot-mock-this-class-exception-in-a-spring-boot-app-457e -->
@@ -99,6 +96,11 @@
 			<artifactId>mockito-core</artifactId>
 			<version>5.5.0</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-pubsub</artifactId>
+			<version>1.126.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
@@ -250,9 +252,15 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>libraries-bom</artifactId>
+				<version>26.29.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>
 				<version>${spring.cloud.gcp.version}</version>
 				<type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.google.cloud</groupId>
-			<artifactId>google-cloud-pubsub</artifactId>
-			<version>1.126.0</version>
-		</dependency>
-		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
 			<version>1.14.8</version>
@@ -255,7 +250,7 @@
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>libraries-bom</artifactId>
-				<version>26.29.0</version>
+				<version>26.34.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/SampleSvcApplication.java
@@ -1,5 +1,9 @@
 package uk.gov.ons.ctp.response.sample;
 
+import com.google.cloud.spring.pubsub.core.PubSubTemplate;
+import com.google.cloud.spring.pubsub.integration.AckMode;
+import com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter;
+import com.google.cloud.spring.pubsub.integration.outbound.PubSubMessageHandler;
 import javax.sql.DataSource;
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -24,10 +28,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
-import org.springframework.cloud.gcp.pubsub.core.PubSubTemplate;
-import org.springframework.cloud.gcp.pubsub.integration.AckMode;
-import org.springframework.cloud.gcp.pubsub.integration.inbound.PubSubInboundChannelAdapter;
-import org.springframework.cloud.gcp.pubsub.integration.outbound.PubSubMessageHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.DependsOn;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/CollectionExerciseEndActivation.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/CollectionExerciseEndActivation.java
@@ -3,13 +3,13 @@ package uk.gov.ons.ctp.response.sample.message;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import java.io.IOException;
 import libs.common.error.CTPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
-import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;

--- a/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleSummaryActivation.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/message/SampleSummaryActivation.java
@@ -3,12 +3,12 @@ package uk.gov.ons.ctp.response.sample.message;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
+import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.gcp.pubsub.support.BasicAcknowledgeablePubsubMessage;
-import org.springframework.cloud.gcp.pubsub.support.GcpPubSubHeaders;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;


### PR DESCRIPTION
# What and why?

This PR migrates the spring cloud pubsub dependencies to google cloud. The functionality should remain the same after the migration. 

# How to test?
Run local and integration tests. 
N.B. the local test will show two failing integration tests, there is a card to address this in the backlog. 
# Jira
https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=1493&projectKey=RAS&view=detail&selectedIssue=RAS-1080