### PR TITLE
Upgrading Spring Boot to 2.7

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.19
+version: 13.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.19
+appVersion: 13.0.20

--- a/pom.xml
+++ b/pom.xml
@@ -94,13 +94,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.5.0</version>
+			<version>5.13.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
-			<version>1.14.8</version>
+			<version>1.15.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.13.0</version>
+			<version>2.16.1</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -135,12 +135,12 @@
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<version>5.8</version>
+			<version>5.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>4.23.1</version>
+			<version>4.29.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
@@ -160,12 +160,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.10.0</version>
+			<version>1.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.hypersistence</groupId>
 			<artifactId>hypersistence-utils-hibernate-55</artifactId>
-			<version>3.5.0</version>
+			<version>3.8.2</version>
 		</dependency>
 		<!-- END -->
 
@@ -208,19 +208,19 @@
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>4.0.3</version>
+			<version>4.0.5</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-core</artifactId>
-			<version>4.0.3</version>
+			<version>4.0.5</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-impl</artifactId>
-			<version>4.0.3</version>
+			<version>4.0.5</version>
 		</dependency>
 
 		<dependency>
@@ -232,7 +232,7 @@
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock</artifactId>
-			<version>2.27.2</version>
+			<version>3.0.1</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -250,7 +250,7 @@
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>libraries-bom</artifactId>
-				<version>26.34.0</version>
+				<version>26.45.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -265,13 +265,13 @@
 			<dependency>
 				<groupId>net.codesup.util</groupId>
 				<artifactId>jaxb2-rich-contract-plugin</artifactId>
-				<version>2.1.0</version>
+				<version>4.1.1</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.testng</groupId>
 				<artifactId>testng</artifactId>
-				<version>7.8.0</version>
+				<version>7.10.2</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -286,7 +286,7 @@
 			<dependency>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.4.1</version>
 			</dependency>
 
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>
-				<version>${spring.cloud.gcp.version}</version>
+				<version>5.6.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</scm>
 	<properties>
 		<springboot.version>2.7.18</springboot.version>
-		<spring.cloud.gcp.version>5.6.0</spring.cloud.gcp.version>
+		<spring.cloud.gcp.version>4.8.0</spring.cloud.gcp.version>
 		<common.version>10.49.4</common.version>
 		<java.version>17</java.version>
 		<surefire.version>3.2.5</surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	</scm>
 	<properties>
 		<springboot.version>2.7.18</springboot.version>
-		<spring.cloud.gcp.version>3.7.8</spring.cloud.gcp.version>
+		<spring.cloud.gcp.version>5.6.0</spring.cloud.gcp.version>
 		<common.version>10.49.4</common.version>
 		<java.version>17</java.version>
 		<surefire.version>3.2.5</surefire.version>
@@ -257,7 +257,7 @@
 			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>spring-cloud-gcp-dependencies</artifactId>
-				<version>5.6.0</version>
+				<version>${spring.cloud.gcp.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<tag>HEAD</tag>
 	</scm>
 	<properties>
-		<springboot.version>2.6.7</springboot.version>
+		<springboot.version>2.7.18</springboot.version>
 		<spring.cloud.gcp.version>3.7.8</spring.cloud.gcp.version>
 		<common.version>10.49.4</common.version>
 		<java.version>17</java.version>


### PR DESCRIPTION
# What and why?

Spring Boot 2.6 is out of support. This upgrades from 2.6 to 2.7

This also upgrades a number of other dependencies including google cloud libraries. Initially the application built and tests passed. However, when deployed into GCP it failed to start due to Spring Boot / GCP library dependencies. I've had to find the most recent compatible GCP library (4.8.0).

# How to test?

Ensure it builds, deploys and the acceptance tests pass. Ensure the app doesn't restart when deployed into a GCP environment due to PubSub bean dependencies.