### PR TITLE
Upgrade actions/cache to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           java-version: 21
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.22
+version: 13.0.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.22
+appVersion: 13.0.23


### PR DESCRIPTION
# What and why?
Upgrades actions/cache from deprecated version to v4
# How to test?
Check the github actions build for successful use of v4
# Jira
https://jira.ons.gov.uk/browse/RAS-1409