### PR TITLE
Use migrated GAR pubsub-emulator image

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.23
+version: 13.0.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.23
+appVersion: 13.0.24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   pubsub-emulator:
     container_name: pubsub-emulator-it
-    image: eu.gcr.io/ons-rasrmbs-management/pubsub-emulator
+    image: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/pubsub-emulator
     ports:
       - "18681:8681"
     environment:


### PR DESCRIPTION
# What and why?

PubSub emulator has been migrated from GCR to GAR

# How to test?

Check the tests run in GHA and locally

# Jira

https://jira.ons.gov.uk/browse/RAS-1423