### PR TITLE
Spelling mistake in groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.testng</groupId>
+				<groupId>org.testing</groupId>
 				<artifactId>testng</artifactId>
 				<version>7.10.2</version>
 				<scope>test</scope>


### PR DESCRIPTION
# What and why?

Replaced `<groupId>org.testng</groupId>` with `<groupId>org.testing</groupId>`.