### PR TITLE
Allow livenessProbe and heap memory allocation

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.27
+version: 13.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.27
+appVersion: 13.0.28

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -96,6 +96,8 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
+          - name: JAVA_OPTS
+            value: {{ .Values.jvm.java_options }}
           - name: DB_HOST
             {{- if .Values.database.managedPostgres }}
             valueFrom:

--- a/_infra/helm/sample/templates/deployment.yaml
+++ b/_infra/helm/sample/templates/deployment.yaml
@@ -88,13 +88,13 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /actuator/info
+              path: {{ .Values.livenessProbe.httpGet.path }}
               port: {{ .Values.container.port }}
-            initialDelaySeconds: 300
-            periodSeconds: 25
-            failureThreshold: 5
-            successThreshold: 1
-            timeoutSeconds: 8
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           env:
           - name: DB_HOST
             {{- if .Values.database.managedPostgres }}

--- a/_infra/helm/sample/values.yaml
+++ b/_infra/helm/sample/values.yaml
@@ -47,6 +47,15 @@ rollingUpdate:
   maxSurge: 1
   maxUnavailable: 1
 
+livenessProbe:
+  httpGet:
+    path: /actuator/info
+  initialDelaySeconds: 1
+  periodSeconds: 20
+  failureThreshold: 2
+  successThreshold: 1
+  timeoutSeconds: 1800
+
 distribution:
   delay: 1000
 

--- a/_infra/helm/sample/values.yaml
+++ b/_infra/helm/sample/values.yaml
@@ -50,9 +50,9 @@ rollingUpdate:
 livenessProbe:
   httpGet:
     path: /actuator/info
-  initialDelaySeconds: 1
-  periodSeconds: 20
-  failureThreshold: 2
+  initialDelaySeconds: 300
+  periodSeconds: 25
+  failureThreshold: 5
   successThreshold: 1
   timeoutSeconds: 1800
 

--- a/_infra/helm/sample/values.yaml
+++ b/_infra/helm/sample/values.yaml
@@ -36,6 +36,9 @@ resources:
       memory: "64Mi"
       cpu: "100m"
 
+jvm:
+   java_options: "-Xms512m -Xmx512m"
+
 autoscaling: false
 scaleAt:
   # These are expressed as a percentage of resources.requests, not resources.limits

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -2,6 +2,9 @@ package uk.gov.ons.ctp.response.sample.service;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -23,9 +26,6 @@ import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitParentDTO;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
 
 @Service
 public class SampleSummaryDistributionService {
@@ -164,18 +164,18 @@ public class SampleSummaryDistributionService {
     return parent;
   }
 
-  private static void printMemoryUsage(String location, MemoryUsage heapUsage, MemoryUsage nonHeapMemory) {
-    LOG.info("Memory Usage",
-             kv("location", location),
-             kv("heapInit", heapUsage.getInit() / (1024 * 1024) + " MB"),
-             kv("heapUsed", heapUsage.getUsed() / (1024 * 1024) + " MB"),
-             kv("heapCommitted", heapUsage.getCommitted() / (1024 * 1024) + " MB"),
-             kv("heapMax", heapUsage.getMax() / (1024 * 1024) + " MB"),
-             kv("stackInit", nonHeapMemory.getInit() / (1024 * 1024) + " MB"),
-             kv("stackUsed", nonHeapMemory.getUsed() / (1024 * 1024) + " MB"),
-             kv("stackCommitted", nonHeapMemory.getCommitted() / (1024 * 1024) + " MB"),
-             kv("stackMax", nonHeapMemory.getMax() / (1024 * 1024) + " MB")
-        );
+  private static void printMemoryUsage(
+      String location, MemoryUsage heapUsage, MemoryUsage nonHeapMemory) {
+    LOG.info(
+        "Memory Usage",
+        kv("location", location),
+        kv("heapInit", heapUsage.getInit() / (1024 * 1024) + " MB"),
+        kv("heapUsed", heapUsage.getUsed() / (1024 * 1024) + " MB"),
+        kv("heapCommitted", heapUsage.getCommitted() / (1024 * 1024) + " MB"),
+        kv("heapMax", heapUsage.getMax() / (1024 * 1024) + " MB"),
+        kv("stackInit", nonHeapMemory.getInit() / (1024 * 1024) + " MB"),
+        kv("stackUsed", nonHeapMemory.getUsed() / (1024 * 1024) + " MB"),
+        kv("stackCommitted", nonHeapMemory.getCommitted() / (1024 * 1024) + " MB"),
+        kv("stackMax", nonHeapMemory.getMax() / (1024 * 1024) + " MB"));
   }
-
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -2,9 +2,6 @@ package uk.gov.ons.ctp.response.sample.service;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -42,8 +39,6 @@ public class SampleSummaryDistributionService {
   private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent>
       sampleUnitTransitionManager;
 
-  MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
-
   /**
    * Distributes the sample units to the case service to create cases against each sample unit. This
    * is done over pubsub.
@@ -58,7 +53,6 @@ public class SampleSummaryDistributionService {
   public void distribute(UUID sampleSummaryId)
       throws NoSampleUnitsInSampleSummaryException, UnknownSampleSummaryException {
     LOG.info("about to distribute sample summary", kv("sampleSummaryId", sampleSummaryId));
-    logMemoryUsage("about to distribute sample summary", memoryBean);
     // first find the correct sample summary
     SampleSummary sampleSummary =
         sampleSummaryRepository
@@ -66,11 +60,11 @@ public class SampleSummaryDistributionService {
             .orElseThrow(UnknownSampleSummaryException::new);
 
     LOG.info("found sample summary", kv("sampleSummary", sampleSummary.getId()));
-    logMemoryUsage("found sample summary", memoryBean);
+
     Stream<SampleUnit> sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
 
     LOG.info("found sample units for summary", kv("sampleSummaryId", sampleSummaryId));
-    logMemoryUsage("found sample units for summary", memoryBean);
+
     // We need to check that the stream length wasn't 0 - we can't check directly as this would
     // consume the stream
     AtomicInteger i = new AtomicInteger(0);
@@ -86,7 +80,6 @@ public class SampleSummaryDistributionService {
                     "distribute sample unit",
                     kv("sampleSummaryId", sampleSummaryId),
                     kv("sampleUnitId", sampleUnit.getId()));
-                logMemoryUsage("distribute sample unit", memoryBean);
                 distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
                 distributeSamples.add(sampleUnit);
 
@@ -106,20 +99,15 @@ public class SampleSummaryDistributionService {
           kv("sampleSummaryId", sampleSummaryId));
       throw new NoSampleUnitsInSampleSummaryException();
     }
-    logMemoryUsage("sampleUnitRepository.saveAll (before)", memoryBean);
     sampleUnitRepository.saveAll(distributeSamples);
-    logMemoryUsage("sampleUnitRepository.flush() (before)", memoryBean);
     sampleUnitRepository.flush();
     // Nothing currently uses this flag, but in the future we'll clean up old samples once they're
     // no longer needed
     LOG.info(
         "Distribution was successful.  Marking sample summary for deletion",
         kv("sampleSummaryId", sampleSummaryId));
-    logMemoryUsage("Marking sample summary for deletion (before)", memoryBean);
     sampleSummary.setMarkForDeletion(true);
-    logMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", memoryBean);
     sampleSummaryRepository.saveAndFlush(sampleSummary);
-    logMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", memoryBean);
   }
 
   /**
@@ -131,21 +119,17 @@ public class SampleSummaryDistributionService {
    */
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
-    logMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
-    logMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
     try {
       LOG.info(
           "Transitioning state of sampleUnit",
           kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
-      logMemoryUsage("Transitioning state of sampleUnit", memoryBean);
       SampleUnitDTO.SampleUnitState newState =
           sampleUnitTransitionManager.transition(
               sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
       sampleUnit.setState(newState);
-      logMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
     } catch (CTPException e) {
       LOG.error("Error occurred whilst transitioning state", e);
     }
@@ -170,28 +154,5 @@ public class SampleSummaryDistributionService {
     parent.setCollectionInstrumentId(sampleUnit.getCollectionInstrumentId());
     parent.setCollectionExerciseId(collectionExerciseId.toString());
     return parent;
-  }
-
-  /**
-   * A temporary method to log memory usage at various points in the distribution process to try and
-   * identify memory leaks.
-   *
-   * @param location The location in the code where the memory usage is being logged
-   * @param memoryBean Singleton MemoryMXBean to get memory usage information from
-   */
-  private static void logMemoryUsage(String location, MemoryMXBean memoryBean) {
-    MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
-    MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
-    LOG.info(
-        "Memory Usage",
-        kv("location", location),
-        kv("heapInit", heapMemory.getInit() / (1024 * 1024) + " MB"),
-        kv("heapUsed", heapMemory.getUsed() / (1024 * 1024) + " MB"),
-        kv("heapCommitted", heapMemory.getCommitted() / (1024 * 1024) + " MB"),
-        kv("heapMax", heapMemory.getMax() / (1024 * 1024) + " MB"),
-        kv("stackInit", nonHeapMemory.getInit() / (1024 * 1024) + " MB"),
-        kv("stackUsed", nonHeapMemory.getUsed() / (1024 * 1024) + " MB"),
-        kv("stackCommitted", nonHeapMemory.getCommitted() / (1024 * 1024) + " MB"),
-        kv("stackMax", nonHeapMemory.getMax() / (1024 * 1024) + " MB"));
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -23,6 +23,9 @@ import uk.gov.ons.ctp.response.sample.domain.repository.SampleUnitRepository;
 import uk.gov.ons.ctp.response.sample.message.SampleUnitPublisher;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitDTO;
 import uk.gov.ons.ctp.response.sample.representation.SampleUnitParentDTO;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
 
 @Service
 public class SampleSummaryDistributionService {
@@ -39,6 +42,10 @@ public class SampleSummaryDistributionService {
   private StateTransitionManager<SampleUnitDTO.SampleUnitState, SampleUnitDTO.SampleUnitEvent>
       sampleUnitTransitionManager;
 
+  MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+  MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
+  MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
+
   /**
    * Distributes the sample units to the case service to create cases against each sample unit. This
    * is done over pubsub.
@@ -53,6 +60,7 @@ public class SampleSummaryDistributionService {
   public void distribute(UUID sampleSummaryId)
       throws NoSampleUnitsInSampleSummaryException, UnknownSampleSummaryException {
     LOG.info("about to distribute sample summary", kv("sampleSummaryId", sampleSummaryId));
+    printMemoryUsage("about to distribute sample summary", heapMemory, nonHeapMemory);
     // first find the correct sample summary
     SampleSummary sampleSummary =
         sampleSummaryRepository
@@ -60,11 +68,11 @@ public class SampleSummaryDistributionService {
             .orElseThrow(UnknownSampleSummaryException::new);
 
     LOG.info("found sample summary", kv("sampleSummary", sampleSummary.getId()));
-
+    printMemoryUsage("found sample summary", heapMemory, nonHeapMemory);
     Stream<SampleUnit> sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
 
     LOG.info("found sample units for summary", kv("sampleSummaryId", sampleSummaryId));
-
+    printMemoryUsage("found sample units for summary", heapMemory, nonHeapMemory);
     // We need to check that the stream length wasn't 0 - we can't check directly as this would
     // consume the stream
     AtomicInteger i = new AtomicInteger(0);
@@ -155,4 +163,19 @@ public class SampleSummaryDistributionService {
     parent.setCollectionExerciseId(collectionExerciseId.toString());
     return parent;
   }
+
+  private static void printMemoryUsage(String location, MemoryUsage heapUsage, MemoryUsage nonHeapMemory) {
+    LOG.info("Memory Usage",
+             kv("location", location),
+             kv("heapInit", heapUsage.getInit() / (1024 * 1024) + " MB"),
+             kv("heapUsed", heapUsage.getUsed() / (1024 * 1024) + " MB"),
+             kv("heapCommitted", heapUsage.getCommitted() / (1024 * 1024) + " MB"),
+             kv("heapMax", heapUsage.getMax() / (1024 * 1024) + " MB"),
+             kv("stackInit", nonHeapMemory.getInit() / (1024 * 1024) + " MB"),
+             kv("stackUsed", nonHeapMemory.getUsed() / (1024 * 1024) + " MB"),
+             kv("stackCommitted", nonHeapMemory.getCommitted() / (1024 * 1024) + " MB"),
+             kv("stackMax", nonHeapMemory.getMax() / (1024 * 1024) + " MB")
+        );
+  }
+
 }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -86,7 +86,7 @@ public class SampleSummaryDistributionService {
                     "distribute sample unit",
                     kv("sampleSummaryId", sampleSummaryId),
                     kv("sampleUnitId", sampleUnit.getId()));
-                // logMemoryUsage("distribute sample unit", memoryBean);
+                logMemoryUsage("distribute sample unit", memoryBean);
                 distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
                 distributeSamples.add(sampleUnit);
 
@@ -131,21 +131,21 @@ public class SampleSummaryDistributionService {
    */
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
-    // logMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
+    logMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
-    // logMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
+    logMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
     try {
       LOG.info(
           "Transitioning state of sampleUnit",
           kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
-      // logMemoryUsage("Transitioning state of sampleUnit", memoryBean);
+      logMemoryUsage("Transitioning state of sampleUnit", memoryBean);
       SampleUnitDTO.SampleUnitState newState =
           sampleUnitTransitionManager.transition(
               sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
       sampleUnit.setState(newState);
-      // logMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
+      logMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
     } catch (CTPException e) {
       LOG.error("Error occurred whilst transitioning state", e);
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -88,6 +88,7 @@ public class SampleSummaryDistributionService {
                     "distribute sample unit",
                     kv("sampleSummaryId", sampleSummaryId),
                     kv("sampleUnitId", sampleUnit.getId()));
+                printMemoryUsage("distribute sample unit", heapMemory, nonHeapMemory);
                 distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
                 distributeSamples.add(sampleUnit);
 
@@ -107,15 +108,20 @@ public class SampleSummaryDistributionService {
           kv("sampleSummaryId", sampleSummaryId));
       throw new NoSampleUnitsInSampleSummaryException();
     }
+    printMemoryUsage("sampleUnitRepository.saveAll (before)", heapMemory, nonHeapMemory);
     sampleUnitRepository.saveAll(distributeSamples);
+    printMemoryUsage("sampleUnitRepository.flush() (before)", heapMemory, nonHeapMemory);
     sampleUnitRepository.flush();
     // Nothing currently uses this flag, but in the future we'll clean up old samples once they're
     // no longer needed
     LOG.info(
         "Distribution was successful.  Marking sample summary for deletion",
         kv("sampleSummaryId", sampleSummaryId));
+    printMemoryUsage("Marking sample summary for deletion (before)", heapMemory, nonHeapMemory);
     sampleSummary.setMarkForDeletion(true);
+    printMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", heapMemory, nonHeapMemory);
     sampleSummaryRepository.saveAndFlush(sampleSummary);
+    printMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", heapMemory, nonHeapMemory);
   }
 
   /**
@@ -127,17 +133,21 @@ public class SampleSummaryDistributionService {
    */
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
+    printMemoryUsage("sendSampleUnitToCase (before)", heapMemory, nonHeapMemory);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
+    printMemoryUsage("sendSampleUnitToCase (after)", heapMemory, nonHeapMemory);
     try {
       LOG.info(
           "Transitioning state of sampleUnit",
           kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
+      printMemoryUsage("Transitioning state of sampleUnit", heapMemory, nonHeapMemory);
       SampleUnitDTO.SampleUnitState newState =
           sampleUnitTransitionManager.transition(
               sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
       sampleUnit.setState(newState);
+      printMemoryUsage("sampleUnitTransitionManager.transition", heapMemory, nonHeapMemory);
     } catch (CTPException e) {
       LOG.error("Error occurred whilst transitioning state", e);
     }

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -58,7 +58,7 @@ public class SampleSummaryDistributionService {
   public void distribute(UUID sampleSummaryId)
       throws NoSampleUnitsInSampleSummaryException, UnknownSampleSummaryException {
     LOG.info("about to distribute sample summary", kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("about to distribute sample summary", memoryBean);
+    logMemoryUsage("about to distribute sample summary", memoryBean);
     // first find the correct sample summary
     SampleSummary sampleSummary =
         sampleSummaryRepository
@@ -66,11 +66,11 @@ public class SampleSummaryDistributionService {
             .orElseThrow(UnknownSampleSummaryException::new);
 
     LOG.info("found sample summary", kv("sampleSummary", sampleSummary.getId()));
-    printMemoryUsage("found sample summary", memoryBean);
+    logMemoryUsage("found sample summary", memoryBean);
     Stream<SampleUnit> sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
 
     LOG.info("found sample units for summary", kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("found sample units for summary", memoryBean);
+    logMemoryUsage("found sample units for summary", memoryBean);
     // We need to check that the stream length wasn't 0 - we can't check directly as this would
     // consume the stream
     AtomicInteger i = new AtomicInteger(0);
@@ -86,7 +86,7 @@ public class SampleSummaryDistributionService {
                     "distribute sample unit",
                     kv("sampleSummaryId", sampleSummaryId),
                     kv("sampleUnitId", sampleUnit.getId()));
-                printMemoryUsage("distribute sample unit", memoryBean);
+                // logMemoryUsage("distribute sample unit", memoryBean);
                 distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
                 distributeSamples.add(sampleUnit);
 
@@ -106,20 +106,20 @@ public class SampleSummaryDistributionService {
           kv("sampleSummaryId", sampleSummaryId));
       throw new NoSampleUnitsInSampleSummaryException();
     }
-    printMemoryUsage("sampleUnitRepository.saveAll (before)", memoryBean);
+    logMemoryUsage("sampleUnitRepository.saveAll (before)", memoryBean);
     sampleUnitRepository.saveAll(distributeSamples);
-    printMemoryUsage("sampleUnitRepository.flush() (before)", memoryBean);
+    logMemoryUsage("sampleUnitRepository.flush() (before)", memoryBean);
     sampleUnitRepository.flush();
     // Nothing currently uses this flag, but in the future we'll clean up old samples once they're
     // no longer needed
     LOG.info(
         "Distribution was successful.  Marking sample summary for deletion",
         kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("Marking sample summary for deletion (before)", memoryBean);
+    logMemoryUsage("Marking sample summary for deletion (before)", memoryBean);
     sampleSummary.setMarkForDeletion(true);
-    printMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", memoryBean);
+    logMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", memoryBean);
     sampleSummaryRepository.saveAndFlush(sampleSummary);
-    printMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", memoryBean);
+    logMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", memoryBean);
   }
 
   /**
@@ -131,21 +131,21 @@ public class SampleSummaryDistributionService {
    */
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
-    printMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
+    // logMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
-    printMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
+    // logMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
     try {
       LOG.info(
           "Transitioning state of sampleUnit",
           kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
-      printMemoryUsage("Transitioning state of sampleUnit", memoryBean);
+      // logMemoryUsage("Transitioning state of sampleUnit", memoryBean);
       SampleUnitDTO.SampleUnitState newState =
           sampleUnitTransitionManager.transition(
               sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
       sampleUnit.setState(newState);
-      printMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
+      // logMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
     } catch (CTPException e) {
       LOG.error("Error occurred whilst transitioning state", e);
     }
@@ -172,7 +172,14 @@ public class SampleSummaryDistributionService {
     return parent;
   }
 
-  private static void printMemoryUsage(String location, MemoryMXBean memoryBean) {
+  /**
+   * A temporary method to log memory usage at various points in the distribution process to try and
+   * identify memory leaks.
+   *
+   * @param location The location in the code where the memory usage is being logged
+   * @param memoryBean Singleton MemoryMXBean to get memory usage information from
+   */
+  private static void logMemoryUsage(String location, MemoryMXBean memoryBean) {
     MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
     MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
     LOG.info(

--- a/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/sample/service/SampleSummaryDistributionService.java
@@ -43,8 +43,6 @@ public class SampleSummaryDistributionService {
       sampleUnitTransitionManager;
 
   MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
-  MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
-  MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
 
   /**
    * Distributes the sample units to the case service to create cases against each sample unit. This
@@ -60,7 +58,7 @@ public class SampleSummaryDistributionService {
   public void distribute(UUID sampleSummaryId)
       throws NoSampleUnitsInSampleSummaryException, UnknownSampleSummaryException {
     LOG.info("about to distribute sample summary", kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("about to distribute sample summary", heapMemory, nonHeapMemory);
+    printMemoryUsage("about to distribute sample summary", memoryBean);
     // first find the correct sample summary
     SampleSummary sampleSummary =
         sampleSummaryRepository
@@ -68,11 +66,11 @@ public class SampleSummaryDistributionService {
             .orElseThrow(UnknownSampleSummaryException::new);
 
     LOG.info("found sample summary", kv("sampleSummary", sampleSummary.getId()));
-    printMemoryUsage("found sample summary", heapMemory, nonHeapMemory);
+    printMemoryUsage("found sample summary", memoryBean);
     Stream<SampleUnit> sampleUnits = sampleService.findSampleUnitsBySampleSummary(sampleSummaryId);
 
     LOG.info("found sample units for summary", kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("found sample units for summary", heapMemory, nonHeapMemory);
+    printMemoryUsage("found sample units for summary", memoryBean);
     // We need to check that the stream length wasn't 0 - we can't check directly as this would
     // consume the stream
     AtomicInteger i = new AtomicInteger(0);
@@ -88,7 +86,7 @@ public class SampleSummaryDistributionService {
                     "distribute sample unit",
                     kv("sampleSummaryId", sampleSummaryId),
                     kv("sampleUnitId", sampleUnit.getId()));
-                printMemoryUsage("distribute sample unit", heapMemory, nonHeapMemory);
+                printMemoryUsage("distribute sample unit", memoryBean);
                 distributeSampleUnit(sampleSummary.getCollectionExerciseId(), sampleUnit);
                 distributeSamples.add(sampleUnit);
 
@@ -108,20 +106,20 @@ public class SampleSummaryDistributionService {
           kv("sampleSummaryId", sampleSummaryId));
       throw new NoSampleUnitsInSampleSummaryException();
     }
-    printMemoryUsage("sampleUnitRepository.saveAll (before)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sampleUnitRepository.saveAll (before)", memoryBean);
     sampleUnitRepository.saveAll(distributeSamples);
-    printMemoryUsage("sampleUnitRepository.flush() (before)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sampleUnitRepository.flush() (before)", memoryBean);
     sampleUnitRepository.flush();
     // Nothing currently uses this flag, but in the future we'll clean up old samples once they're
     // no longer needed
     LOG.info(
         "Distribution was successful.  Marking sample summary for deletion",
         kv("sampleSummaryId", sampleSummaryId));
-    printMemoryUsage("Marking sample summary for deletion (before)", heapMemory, nonHeapMemory);
+    printMemoryUsage("Marking sample summary for deletion (before)", memoryBean);
     sampleSummary.setMarkForDeletion(true);
-    printMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sampleSummaryRepository.saveAndFlush (before)", memoryBean);
     sampleSummaryRepository.saveAndFlush(sampleSummary);
-    printMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sampleSummaryRepository.saveAndFlush (after)", memoryBean);
   }
 
   /**
@@ -133,21 +131,21 @@ public class SampleSummaryDistributionService {
    */
   public void distributeSampleUnit(UUID collectionExerciseId, SampleUnit sampleUnit) {
     SampleUnitParentDTO parent = createSampleUnitParentDTOObject(collectionExerciseId, sampleUnit);
-    printMemoryUsage("sendSampleUnitToCase (before)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sendSampleUnitToCase (before)", memoryBean);
     sampleUnitPublisher.sendSampleUnitToCase(parent);
-    printMemoryUsage("sendSampleUnitToCase (after)", heapMemory, nonHeapMemory);
+    printMemoryUsage("sendSampleUnitToCase (after)", memoryBean);
     try {
       LOG.info(
           "Transitioning state of sampleUnit",
           kv("id", sampleUnit.getId()),
           kv("from", sampleUnit.getState()),
           kv("to", SampleUnitDTO.SampleUnitEvent.DELIVERING));
-      printMemoryUsage("Transitioning state of sampleUnit", heapMemory, nonHeapMemory);
+      printMemoryUsage("Transitioning state of sampleUnit", memoryBean);
       SampleUnitDTO.SampleUnitState newState =
           sampleUnitTransitionManager.transition(
               sampleUnit.getState(), SampleUnitDTO.SampleUnitEvent.DELIVERING);
       sampleUnit.setState(newState);
-      printMemoryUsage("sampleUnitTransitionManager.transition", heapMemory, nonHeapMemory);
+      printMemoryUsage("sampleUnitTransitionManager.transition", memoryBean);
     } catch (CTPException e) {
       LOG.error("Error occurred whilst transitioning state", e);
     }
@@ -174,15 +172,16 @@ public class SampleSummaryDistributionService {
     return parent;
   }
 
-  private static void printMemoryUsage(
-      String location, MemoryUsage heapUsage, MemoryUsage nonHeapMemory) {
+  private static void printMemoryUsage(String location, MemoryMXBean memoryBean) {
+    MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
+    MemoryUsage nonHeapMemory = memoryBean.getNonHeapMemoryUsage();
     LOG.info(
         "Memory Usage",
         kv("location", location),
-        kv("heapInit", heapUsage.getInit() / (1024 * 1024) + " MB"),
-        kv("heapUsed", heapUsage.getUsed() / (1024 * 1024) + " MB"),
-        kv("heapCommitted", heapUsage.getCommitted() / (1024 * 1024) + " MB"),
-        kv("heapMax", heapUsage.getMax() / (1024 * 1024) + " MB"),
+        kv("heapInit", heapMemory.getInit() / (1024 * 1024) + " MB"),
+        kv("heapUsed", heapMemory.getUsed() / (1024 * 1024) + " MB"),
+        kv("heapCommitted", heapMemory.getCommitted() / (1024 * 1024) + " MB"),
+        kv("heapMax", heapMemory.getMax() / (1024 * 1024) + " MB"),
         kv("stackInit", nonHeapMemory.getInit() / (1024 * 1024) + " MB"),
         kv("stackUsed", nonHeapMemory.getUsed() / (1024 * 1024) + " MB"),
         kv("stackCommitted", nonHeapMemory.getCommitted() / (1024 * 1024) + " MB"),


### PR DESCRIPTION
# What and why?

An initial attempt to stop sample service receiving a sigterm during long running processes (sample load and enrichment/case distribution)

- allow us to override livenessProbe to stop Kubernetes from killing long running processes
- allow explicit `JAVA_OPTIONS` to allocate more heap