### PR TITLE
Upgrade logstash and jackson

### DIFF
--- a/_infra/helm/sample/Chart.yaml
+++ b/_infra/helm/sample/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 13.0.28
+version: 13.0.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 13.0.28
+appVersion: 13.0.29

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<spring.cloud.gcp.version>5.6.0</spring.cloud.gcp.version>
 		<common.version>10.49.4</common.version>
 		<java.version>21</java.version>
+		<jackson.version>2.21</jackson.version>
 		<surefire.version>3.2.5</surefire.version>
 		<skipSurefire>false</skipSurefire>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -113,6 +114,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
+			<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
@@ -121,7 +123,7 @@
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<version>8.0</version>
+			<version>9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
# What and why?
Upgrades logstash-logback-encoder to version 9.0 and then as a consequence upgrades jackson-annotations to version 2.21 the most recent and compatible version. 
The card was originally to upgrade to version 8.0 but as we have already moved to that version taking the opportunity to upgrade to latest. 
# How to test?
Check sample builds locally and the tests pass, check the jackson upgrade is working by deploy this PR to your env and testing sample. 
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1279